### PR TITLE
Improve the landing video component

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -12,6 +12,8 @@ import gitlabBaseCase from "media/gitlab/base-case-report.png"
 import gitlabDVCReport from "media/gitlab/dvc-report.png"
 import gitlabTensorboardReport from "media/gitlab/tensorboard-report.png"
 
+import LandingVideo from "components/molecules/Video/LandingVideo"
+
 <FullWidthBox sx={{
   backgroundColor: "text",
   color: "background",
@@ -40,8 +42,8 @@ import gitlabTensorboardReport from "media/gitlab/tensorboard-report.png"
     <Box sx={{flex: "1"}}>
       <Switch sx={{ mt: 4, mx: "auto", maxWidth: ["100%", null, "160px"] }} />
       <Switchable
-        gitlab={<Video src={gitlabVideo} mode="gitlab" />}
-        github={<Video src={githubVideo} mode="github" />}
+        gitlab={<LandingVideo src={gitlabVideo} mode="gitlab" />}
+        github={<LandingVideo src={githubVideo} mode="github" />}
       />
     </Box>
   </Collapser>

--- a/src/components/molecules/Video/LandingVideo/index.js
+++ b/src/components/molecules/Video/LandingVideo/index.js
@@ -1,0 +1,14 @@
+import React from "react"
+import Video from "../"
+
+const LandingVideo = props => (
+  <Video
+    variant="styles.LandingVideo"
+    controls={false}
+    autoPlay={true}
+    repeat={true}
+    {...props}
+  />
+)
+
+export default LandingVideo

--- a/src/components/molecules/Video/index.js
+++ b/src/components/molecules/Video/index.js
@@ -1,0 +1,56 @@
+import React, { useContext, useEffect, useRef } from "react"
+import { ModeContext } from "components/organisms/SwitchableMode/Provider"
+import { Box } from "@theme-ui/components"
+
+const Video = ({
+  sx = {},
+  src,
+  mode,
+  controls = false,
+  playsinline = true,
+  autoPlay = !controls,
+  variant = "styles.Video",
+  ...rest
+}) => {
+  const contextMode = useContext(ModeContext)
+  const videoRef = useRef()
+  const videoElement = videoRef.current
+
+  useEffect(() => {
+    if (mode && videoElement) {
+      if (contextMode !== mode) {
+        videoElement.pause()
+      } else if (autoPlay) {
+        videoElement.play()
+      }
+    }
+  }, [mode, contextMode, videoElement, autoPlay])
+  return (
+    <Box
+      variant={variant}
+      sx={{
+        position: "relative",
+        ...sx,
+      }}
+      {...rest}
+    >
+      <Box
+        as="video"
+        sx={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+        }}
+        ref={videoRef}
+        autoPlay={autoPlay}
+        playsinline={playsinline}
+        controls={controls}
+        src={src}
+      />
+    </Box>
+  )
+}
+
+export default Video

--- a/src/gatsby-plugin-theme-ui/components.js
+++ b/src/gatsby-plugin-theme-ui/components.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useRef } from "react"
 import { ModeContext } from "components/organisms/SwitchableMode/Provider"
 import SolutionLineArrow from "./solution-line-arrow.svg"
 import Collapser from "components/atoms/Collapser"
+import Video from "components/molecules/Video"
 import {
   Button,
   Flex,
@@ -135,43 +136,6 @@ const FullWidthBox = ({
     <Box variant="styles.FullWidthBox" className={className} sx={sx} {...props}>
       <Container sx={inner}>{children}</Container>
     </Box>
-  )
-}
-
-FullWidthBox.isFullWidth = true
-
-const Video = ({
-  sx = {},
-  mode,
-  autoplay,
-  playsinline = true,
-  controls = true,
-  ...props
-}) => {
-  const contextMode = useContext(ModeContext)
-  const videoRef = useRef()
-  const videoElement = videoRef.current
-  useEffect(() => {
-    if (mode) {
-      if (contextMode !== mode && videoElement) {
-        videoElement.pause()
-      }
-    }
-  }, [mode, contextMode, videoElement])
-  return (
-    <Box
-      as="video"
-      ref={videoRef}
-      autoplay={autoplay}
-      playsinline={playsinline}
-      controls={controls}
-      sx={{
-        my: 4,
-        maxWidth: "100%",
-        ...sx,
-      }}
-      {...props}
-    />
   )
 }
 

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -349,6 +349,15 @@ export default {
   },
   styles: {
     ...preset.styles,
+    LandingVideo: {
+      height: "0",
+      width: "auto",
+      paddingBottom: "66%",
+      borderRadius: "8px",
+      backgroundColor: "black",
+      overflow: "hidden",
+      my: 3,
+    },
     Highlight: {
       textDecoration: "inherit",
       transition: "0.2s all",
@@ -378,11 +387,10 @@ export default {
         backgroundColor: "background",
         color: "text",
         width: "auto",
-        height: "auto",
+        height: "44px",
         fontFamily: "body",
         fontSize: ["14px", null, "18px"],
         top: "-54px",
-        height: "44px",
         px: "1em",
         lineHeight: "44px",
         borderRadius: "4px",


### PR DESCRIPTION
This PR improves the Video component, especially for use on the landing page.

The landing video uses the absolute padding technique to fluidly lock at 66% aspect ratio, which is the ratio used in the Figma.  
However, this ratio can be changed so this isn't necessarily a prescription for the new video resolution.