### PR TITLE
Add Webp to content and logo images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -60,6 +60,7 @@ module.exports = {
           require.resolve(`./remarkPlugin.js`),
           {
             resolve: `gatsby-remark-images`,
+            withWebp: true,
             options: {
               maxWidth: 590,
             },

--- a/src/components/atoms/SiteLogo/index.js
+++ b/src/components/atoms/SiteLogo/index.js
@@ -15,7 +15,7 @@ function SiteLogo({ ...props }) {
       ) {
         childImageSharp {
           fluid(maxWidth: 154) {
-            ...GatsbyImageSharpFluid
+            ...GatsbyImageSharpFluid_withWebp
           }
         }
       }


### PR DESCRIPTION
Partially for saving bandwidth, partially because Google probably treats them better for Lighthouse purposes. It's basically just flipping the feature switch on.