### PR TITLE
Set nav/footer transitions to 0.2 for consistency

### DIFF
--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -74,6 +74,7 @@ export default {
     },
     Header: {
       color: "background",
+      backgroundColor: "text",
       py: ["12px", null, "20px", "36px"],
       pb: ["6px", null, "20px", "36px"],
       px: ["16px", null, "32px", "80px"],


### PR DESCRIPTION
* the footer had links with `transition` of `0.5` and one of our nav items had a transition of `0.25`. I updated the transitions so they were all set to `0.2` since most transitions on the site were `0.2`.
* I also added a `background-color` to the `Header` since I just noticed that it had no background on the cml.dev 404 page. Though looking at the 404 page, it looks like it at least needs some padding to the sides. 🤔 Should I create a issue?