### PR TITLE
Fix repeated secrets property on GitHub snippets

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -669,7 +669,7 @@ jobs:
       - name: deploy
         shell: bash
         env:
-          repo_token: { "${{ secrets.secrets.PERSONAL_ACCESS_TOKEN }}" }
+          repo_token: { "${{ secrets.PERSONAL_ACCESS_TOKEN }}" }
           AWS_ACCESS_KEY_ID: { "${{ secrets.AWS_ACCESS_KEY_ID }}" }
           AWS_SECRET_ACCESS_KEY: { "${{ secrets.AWS_SECRET_ACCESS_KEY }}" } 
         run: |
@@ -702,7 +702,7 @@ jobs:
 
     - name: cml
       env:
-        repo_token: { "${{ secrets.secrets.PERSONAL_ACCESS_TOKEN }}" }
+        repo_token: { "${{ secrets.PERSONAL_ACCESS_TOKEN }}" }
       run: |
         apt-get update -y
         apt install imagemagick -y


### PR DESCRIPTION
### Follow-up of [#cml➔1623248851315700](https://iterativeai.slack.com/archives/C01900GSB4J/p1623248851315700)

> Secrets aren't meant to be repeated. :joy: Can we remove one of them?
> ![captura_de_pantalla_2021-06-09_a_las_16 24 38_720](https://user-images.githubusercontent.com/11387611/122557523-307ccd80-d03d-11eb-8751-152297f9e225.png)
