### PR TITLE
Fix cml-with-dvc page's link on index.md

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -16,7 +16,7 @@ and monitoring changing datasets.
     Study the detailed inner-workings of CML in its user guide.
   </card>
 
-  <card href="/doc/use-cases" heading="CML with DVC">
+  <card href="/doc/cml-with-dvc" heading="CML with DVC">
     Bring data to your CML runner with DVC
   </card>
 


### PR DESCRIPTION
Hi 👋 
- Fixed cml-with-dvc page's link.
  - before: https://cml.dev/doc/use-cases
  - after: https://cml.dev/doc/cml-with-dvc