### PR TITLE
rename cml-website => cml.dev, add contrib docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ Start by cloning this repo:
 Get the full history with
 
 ```bash
-git clone https://github.com/iterative/cml-website
+git clone https://github.com/iterative/cml.dev
 ```
 
 Alternatively, you can save some space with a shallow clone:
 
 ```bash
-git clone --depth 1 https://github.com/iterative/cml-website
+git clone --depth 1 https://github.com/iterative/cml.dev
 ```
 
 From here, go into the cloned directory and install packages
 
 ```bash
-cd cml-website
+cd cml.dev
 yarn
 ```
 

--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -1,0 +1,41 @@
+# Contributing to CML
+
+We welcome contributions to [CML](https://github.com/iterative/cml) by the
+community. See the [Contributing to the Documentation](/doc/contributing/docs)
+guide if you want to fix or update the documentation or this website.
+
+## How to report a problem
+
+Please search [issue tracker](https://github.com/iterative/cml/issues) before
+creating a new issue (problem or an improvement request). Feel free to add
+issues related to the project.
+
+For problems with the [cml.dev](https://cml.dev) site, please use this
+[GitHub repository](https://github.com/iterative/cml-website).
+
+If you feel that you can fix or implement it yourself, please read a few
+paragraphs below to learn how to submit your changes.
+
+## Contributions
+
+Pull request tests won't run until maintainers approve them.
+
+## Coding conventions
+
+All the CML JavaScript code should follow the
+[Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript).
+
+## Maintenance
+
+### New pull requests
+
+1. Use a branch and create a pull request targeting the `master` branch
+2. Release managers will be in charge of merging pull requests after a one or
+   more approving review.
+
+## New releases
+
+1. `git checkout master && git pull && npm version vM.m.p && git push && git push --tags`
+2. Draft a new [release](https://github.com/iterative/cml/releases)
+   - make sure all commits since last release are summarised in the release
+     notes

--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -1,20 +1,23 @@
 # Contributing to CML
 
-We welcome contributions to [CML](https://github.com/iterative/cml) by the
-community. See the [Contributing to the Documentation](/doc/contributing/docs)
-guide if you want to fix or update the documentation or this website.
+We welcome contributions to [CML][cml-repo] by the community. See the
+[Contributing to the Documentation](/doc/contributing/docs) guide if you want to
+fix or update the documentation or this website.
 
-## How to report a problem
+[cml-repo]: https://github.com/iterative/cml
 
-Please search [issue tracker](https://github.com/iterative/cml/issues) before
-creating a new issue (problem or an improvement request). Feel free to add
-issues related to the project.
+## Reporting a Problem
 
-For problems with the [cml.dev](https://cml.dev) site, please use this
-[GitHub repository](https://github.com/iterative/cml.dev).
+Spotted a bug? Let us know!
 
-If you feel that you can fix or implement it yourself, please read a few
-paragraphs below to learn how to submit your changes.
+- For problems with [CML][cml-repo], search the
+  [issue tracker](https://github.com/iterative/cml/issues) before creating a new
+  issue (problem or an improvement request).
+- If you'd like implement/fix things yourself, please see below for help on how
+  to submit your changes.
+
+> For problems with the [cml.dev](/) site, please see
+> [Contributing to the Documentation](/doc/contributing/docs) instead.
 
 ## Contributions
 

--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -11,7 +11,7 @@ creating a new issue (problem or an improvement request). Feel free to add
 issues related to the project.
 
 For problems with the [cml.dev](https://cml.dev) site, please use this
-[GitHub repository](https://github.com/iterative/cml-website).
+[GitHub repository](https://github.com/iterative/cml.dev).
 
 If you feel that you can fix or implement it yourself, please read a few
 paragraphs below to learn how to submit your changes.

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -1,7 +1,7 @@
 # Contributing to the Documentation
 
 We welcome any contributions to our documentation repository,
-[cml-website](https://github.com/iterative/cml-website). Contributions can be
+[cml.dev](https://github.com/iterative/cml.dev). Contributions can be
 updates to the documentation content, or (rare) changes to the JS engine we use
 to run the website.
 

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -1,0 +1,14 @@
+# Contributing to the Documentation
+
+We welcome any contributions to our documentation repository,
+[cml-website](https://github.com/iterative/cml-website). Contributions can be
+updates to the documentation content, or (rare) changes to the JS engine we use
+to run the website.
+
+In case of a minor change, you can use the **Edit on GitHub** button to open the
+source code page. Use thethe Edit button (pencil icon) to edit the file
+in-place, and then **Commit changes** from the bottom of the page.
+
+> Please see our
+> [sister website's Contributing to Documentation guide](https://dvc.org/doc/user-guide/contributing/docs)
+> for full details.

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -1,14 +1,14 @@
 # Contributing to the Documentation
 
-We welcome any contributions to our documentation repository,
-[cml.dev](https://github.com/iterative/cml.dev). Contributions can be
+We welcome any contributions to our website's source
+[GitHub repository](https://github.com/iterative/cml.dev). Contributions can be
 updates to the documentation content, or (rare) changes to the JS engine we use
 to run the website.
 
 In case of a minor change, you can use the **Edit on GitHub** button to open the
-source code page. Use thethe Edit button (pencil icon) to edit the file
-in-place, and then **Commit changes** from the bottom of the page.
+source code page. Use the Edit button (pencil icon) to edit the file in-place,
+and then **Commit changes** from the bottom of the page.
 
-> Please see our
-> [sister website's Contributing to Documentation guide](https://dvc.org/doc/user-guide/contributing/docs)
-> for full details.
+Please see our sister website's
+[Contributing to Documentation guide](https://dvc.org/doc/user-guide/contributing/docs)
+for full details.

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -32,5 +32,20 @@
   {
     "label": "Install as a Package",
     "slug": "cml-with-npm"
+  },
+  {
+    "label": "Contributing",
+    "slug": "contributing",
+    "source": false,
+    "children": [
+      {
+        "label": "CML Core Project",
+        "slug": "core"
+      },
+      {
+        "label": "Docs and Website",
+        "slug": "docs"
+      }
+    ]
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cml-website",
+  "name": "cml.dev",
   "version": "1.0.0",
   "description": "cml.dev – website source code",
   "main": "index.js",
@@ -23,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/cml-website"
+    "url": "https://github.com/gatsbyjs/cml.dev"
   },
   "author": "",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
-  "homepage": "https://github.com/iterative/cml-website#readme",
+  "homepage": "https://github.com/iterative/cml.dev#readme",
   "engines": {
     "node": "<=15.x"
   },

--- a/src/components/pages/Documentation/index.tsx
+++ b/src/components/pages/Documentation/index.tsx
@@ -22,7 +22,7 @@ const Documentation: React.FC<IDocumentationProps> = ({
   headings
 }) => {
   const { source, prev, next, tutorials } = getItemByPath(path)
-  const githubLink = `https://github.com/iterative/cml-website/blob/master/content${source}`
+  const githubLink = `https://github.com/iterative/cml.dev/blob/master/content${source}`
 
   return (
     <>


### PR DESCRIPTION
fixes #69

- [x] add new `contributing/core` based off dvc.org
- [x] add new `contributing/docs` linking to dvc.org
- [x] rename this repo from `cml-website` to `cml.dev`
  - [x] update links
- [ ] follow-up (post-merge)
  - [ ] update https://github.com/iterative/cml/wiki/Contributing to redirect to https://cml.dev/doc/contributing/core
  - [ ] flesh out `contributing/core` more