### PR TITLE
Remove extraneous GitLab callout

### DIFF
--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -7,10 +7,6 @@ supported CI systems (with exceptions as noted!).
 1. Fork our
    [example project repository](https://github.com/iterative/example_cml).
 
-   ⚠️ If you are using GitLab,
-   [you'll need to create a Personal Access Token](https://github.com/iterative/cml/wiki/CML-with-GitLab#variables)
-   for this example to work.
-
    ![](/img/fork_cml_project.png)
 
    The following steps can all be done in the GitHub browser interface. However,

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -1,8 +1,8 @@
 # Get Started with CML on GitHub
 
 Here, we'll walk through a tutorial to start using CML. For simplicity, we'll
-show the demo in GitHub Actions, but these instructions are valid for all
-supported CI systems (with exceptions as noted!).
+show the demo in GitHub Actions, but instructions are pretty similar for all
+the supported CI systems.
 
 1. Fork our
    [example project repository](https://github.com/iterative/example_cml).

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -1,8 +1,8 @@
 # Get Started with CML on GitHub
 
 Here, we'll walk through a tutorial to start using CML. For simplicity, we'll
-show the demo in GitHub Actions, but instructions are pretty similar for all
-the supported CI systems.
+show the demo in GitHub Actions, but instructions are pretty similar for all the
+supported CI systems.
 
 1. Fork our
    [example project repository](https://github.com/iterative/example_cml).


### PR DESCRIPTION
It looks like that text doesn't belong to the GitHub documentation, and we still have separate sections for GitHub and GitLab. 🤔 