### PR TITLE
fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ yarn
 ```
 
 With the setup finished, you can now spin up the development server at
-`localhost:8000` with `gatsby develop` or try a full local build at
-`localhost:9000` with `gatsby build && gatsby serve`.
+<http://localhost:8000> with `yarn develop` or try a full local build at
+<http://localhost:9000> with `yarn build && gatsby serve`.
 
 # Getting help
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CML](https://static.iterative.ai/img/title_strip_trim.svg)
+![CML](https://static.iterative.ai/img/cml/title_strip_trim.png)
 
 [![CircleCI](https://circleci.com/gh/iterative/cml.dev.svg?style=svg)](https://circleci.com/gh/iterative/cml.dev)
 [![Link Check](https://github.com/iterative/cml.dev/workflows/Check%20all%20links%20in%20the%20repository/badge.svg)](https://github.com/iterative/cml.dev/actions?query=workflow%3A%22Check+all+links+in+the+repository%22)
@@ -37,8 +37,8 @@ very responsive and happy to help.
 Source code of this project is distributed under the Apache license version 2.0
 (see the LICENSE file in the project root).
 
-Except where otherwise noted, documentation, blog content, images are licensed
-under a [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.
+Except where otherwise noted, documentation and images are licensed under a
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0) license.
 
 By submitting a pull request for this project, you agree to license your
 contribution under the Apache license 2.0 (source code) or CC BY 4.0

--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -1,2 +1,4 @@
 - 'http://localhost:8000**'
 - 'http://localhost:9000**'
+- 'https://dvc.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a'
+- '**linkedin.com/company/**'

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -18,7 +18,7 @@ We built CML with these principles in mind:
 - **[GitFlow](https://nvie.com/posts/a-successful-git-branching-model/) for data
   science.** Use GitLab or GitHub to manage ML experiments, track who trained ML
   models or modified data and when. Codify data and models with
-  [DVC](/doc/cml/cml-with-dvc) instead of pushing to a Git repo.
+  [DVC](/doc/cml-with-dvc) instead of pushing to a Git repo.
 - **Auto reports for ML experiments.** Auto-generate reports with metrics and
   plots in each Git Pull Request. Rigorous engineering practices help your team
   make informed, data-driven decisions.

--- a/src/components/organisms/SubscribeSection/Form/index.tsx
+++ b/src/components/organisms/SubscribeSection/Form/index.tsx
@@ -22,7 +22,7 @@ const Form: React.FC = () => {
   return (
     <form
       className={styles.form}
-      action="https://sweedom.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a"
+      action="https://dvc.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a"
       method="post"
       id="mc-embedded-subscribe-form"
       name="mc-embedded-subscribe-form"


### PR DESCRIPTION
Running `link-check` (assuming https://github.com/iterative/link-check/pull/8 is merged) also yields:

  - FAIL: https://dvc.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a (406)
  - FAIL: https://www.linkedin.com/company/iterative-ai (999)
  - FAIL: https://www.linkedin.com/company/iterative-ai (999)
  - FAIL: https://sweedom.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a (406)

should they be excluded? Odd error codes (`406 not acceptable` and `999 who uses linkedin anyway`) and also 2 different mailing list links?