### PR TITLE
Convert H3 in H4 for H3 childs

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -127,7 +127,7 @@ to provide the following secrets:
 
 <details>
 
-### GitHub
+#### GitHub
 
 You can either
 [create a personal access token](https://docs.github.com/en/github-ae@latest/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
@@ -141,7 +141,7 @@ write permissions (for organization-level runners).
 
 <details>
 
-### GitLab
+#### GitLab
 
 You can either
 [create a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
@@ -173,7 +173,7 @@ Click below to see credentials needed for supported cloud service providers.
 
 <details>
 
-### AWS
+#### AWS
 
 ```yaml
 env:
@@ -188,7 +188,7 @@ Note that `AWS_SESSION_TOKEN` is optional.
 
 <details>
 
-### Azure
+#### Azure
 
 ```yaml
 env:


### PR DESCRIPTION
Follow-up of https://github.com/iterative/cml.dev/pull/90#discussion_r693111314: all the `<details>` elements included in `<h3>` headings should have `<h4>` headings for the `<summary>` part.

***

> You may disregard these recommendations if you used the **Edit on GitHub** button from dvc.org to improve a doc in place.

❗ Please read the guidelines in the [Contributing to the Documentation](https://dvc.org/doc/user-guide/contributing/docs) list if you make any substantial changes to the documentation or JS engine.

🐛 Please make sure to mention `Fix #issue` (if applicable) in the description of the PR. This causes GitHub to close it automatically when the PR is merged.

Please choose to [allow us](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to edit your branch when creating the PR.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
