### PR TITLE
Clear all `yarn lint-ts` warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,9 @@
       "files": [
         "src/utils/shared/*.?(js|ts)",
         "src/gatsby/**/*.js",
-        "src/components/PageWrapper/index.js",
+        "src/components/**/*.js",
+        "src/utils/**/*.js",
+        "src/gatsby-plugin-theme-ui/**/*.js",
         "scripts/**/*.js",
         "config/**/*.js",
         "src/server/**/*.js",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,18 +33,7 @@
   },
   "overrides": [
     {
-      "files": [
-        "src/utils/shared/*.?(js|ts)",
-        "src/gatsby/**/*.js",
-        "src/components/**/*.js",
-        "src/utils/**/*.js",
-        "src/gatsby-plugin-theme-ui/**/*.js",
-        "scripts/**/*.js",
-        "config/**/*.js",
-        "src/server/**/*.js",
-        "gatsby-*.js",
-        "postcss.config.js"
-      ],
+      "files": "**/*.js",
       "rules": {
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/explicit-function-return-type": "off"

--- a/src/components/organisms/SiteHeader/index.tsx
+++ b/src/components/organisms/SiteHeader/index.tsx
@@ -121,12 +121,12 @@ const Header: React.FC<IHeaderProps> = ({ isMain }) => {
   const installPopupContainerEl = useRef<HTMLDivElement>(null)
   const otherToolsPopupContainerEl = useRef<HTMLDivElement>(null)
 
-  const closeAllPopups = () => {
+  const closeAllPopups = (): void => {
     setIsInstallPopupOpen(false)
     setIsOtherToolsPopupOpen(false)
   }
 
-  const handlePageClick = (event: MouseEvent) => {
+  const handlePageClick = (event: MouseEvent): void => {
     if (
       event.target instanceof Element &&
       !installPopupContainerEl?.current?.contains(event.target) &&
@@ -136,25 +136,25 @@ const Header: React.FC<IHeaderProps> = ({ isMain }) => {
     }
   }
 
-  const handlePageKeyup = (event: KeyboardEvent) => {
+  const handlePageKeyup = (event: KeyboardEvent): void => {
     if (event.key === 'Escape') {
       closeAllPopups()
     }
   }
 
-  const openInstallPopup = () => {
+  const openInstallPopup = (): void => {
     document.addEventListener('click', handlePageClick)
     document.addEventListener('keyup', handlePageKeyup)
     setIsInstallPopupOpen(true)
   }
 
-  const openOtherToolsPopup = () => {
+  const openOtherToolsPopup = (): void => {
     document.addEventListener('click', handlePageClick)
     document.addEventListener('keyup', handlePageKeyup)
     setIsOtherToolsPopupOpen(true)
   }
 
-  const toggleInstallPopup = () => {
+  const toggleInstallPopup = (): void => {
     setIsOtherToolsPopupOpen(false)
     if (isInstallPopupOpen) {
       closeAllPopups()
@@ -163,7 +163,7 @@ const Header: React.FC<IHeaderProps> = ({ isMain }) => {
     }
   }
 
-  const toggleOtherToolsPopup = () => {
+  const toggleOtherToolsPopup = (): void => {
     setIsInstallPopupOpen(false)
     if (isOtherToolsPopupOpen) {
       closeAllPopups()


### PR DESCRIPTION
* updates our `.eslintrc.json` `overrides.files` array, adding folders that have `js` files. Otherwise we get typescript warnings on some our `js` files in `src`.
* fixes typescript errors in `src/components/organisms/SiteHeader`