### PR TITLE
ref: first stubs

### DIFF
--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -1,0 +1,20 @@
+# Command Reference: `pr`
+
+Commit specified files to a new branch and create a pull request.
+
+```dvc
+cml pr '**/*.py' '**/*.json'
+```
+
+is roughly equivalent to:
+
+```dvc
+SHA="$(git log -n1 --format=%h)"
+BASE="$(git branch)"
+git checkout -b "${BASE}-cml-pr-${SHA}"
+git add *.py *.json
+git commit -m "CML PR for ${SHA} [skip ci]"
+git push
+gh pr create -B ${BASE}
+git checkout -
+```

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -16,5 +16,4 @@ git add *.py *.json
 git commit -m "CML PR for ${SHA} [skip ci]"
 git push
 gh pr create -B ${BASE}
-git checkout -
 ```

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -1,0 +1,9 @@
+# Command Reference: `publish`
+
+Publish an image for inclusion in a CML report.
+
+To render an image in a markdown file:
+
+```dvc
+cml publish --md ./some-image.png >> report.md
+```

--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -1,5 +1,4 @@
 # Command Reference: `runner`
 
-Starts a runner (either via any supported cloud compute provider or locally
-on-premise -- see
-[cloud compute resource credentials](/doc/self-hosted-runners#cloud-compute-resource-credentials)).
+Starts a [runner](/doc/self-hosted-runners) (either via any supported cloud
+compute provider or locally on-premise).

--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -1,0 +1,5 @@
+# Command Reference: `runner`
+
+Starts a runner (either via any supported cloud compute provider or locally
+on-premise -- see
+[cloud compute resource credentials](/doc/self-hosted-runners#cloud-compute-resource-credentials)).

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -11,9 +11,9 @@ cml send-comment some_content.md
 - Can't create a pull request comment: the Pull Request Commit Links application
   has not been installed.
 
-  - We don't like ClickOps either but here's an actual
-    [quote from the Bitbucket docs](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commit/%7Bcommit%7D/pullrequests):
+We don't like ClickOps either but here's an actual
+[quote from the Bitbucket docs](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commit/%7Bcommit%7D/pullrequests):
 
-  > Pull Request Commit Links app must be installed first before using this API;
-  > installation automatically occurs when 'Go to pull request' is clicked from
-  > the web interface for a commit's details.
+> Pull Request Commit Links app must be installed first before using this API;
+> installation automatically occurs when 'Go to pull request' is clicked from
+> the web interface for a commit's details.

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -1,0 +1,14 @@
+# Command Reference: `send-comment`
+
+```dvc
+cml send-comment some_content.md
+```
+
+## Common error messages
+
+### Bitbucket
+
+- Can't create a pull request comment: the Pull Request Commit Links application
+  has not been installed.
+
+  > [Pull Request Commit Links app must be installed first before using this API; installation automatically occurs when 'Go to pull request' is clicked from the web interface for a commit's details.](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commit/%7Bcommit%7D/pullrequests)

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -11,4 +11,9 @@ cml send-comment some_content.md
 - Can't create a pull request comment: the Pull Request Commit Links application
   has not been installed.
 
-  > [Pull Request Commit Links app must be installed first before using this API; installation automatically occurs when 'Go to pull request' is clicked from the web interface for a commit's details.](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commit/%7Bcommit%7D/pullrequests)
+  - We don't like ClickOps either but here's an actual
+    [quote from the Bitbucket docs](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/commit/%7Bcommit%7D/pullrequests):
+
+  > Pull Request Commit Links app must be installed first before using this API;
+  > installation automatically occurs when 'Go to pull request' is clicked from
+  > the web interface for a commit's details.

--- a/content/docs/ref/send-github-check.md
+++ b/content/docs/ref/send-github-check.md
@@ -1,0 +1,8 @@
+# Command Reference: `send-github-check`
+
+Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
+[checks interface](https://docs.github.com/en/rest/reference/checks).
+
+```dvc
+cml send-github-check some_content.md
+```

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -1,0 +1,7 @@
+# Command Reference: `tensorboard-dev`
+
+Return a link to a <https://tensorboard.dev> page.
+
+```dvc
+cml tensorboard-dev
+```

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -32,6 +32,7 @@
   {
     "label": "Command Reference",
     "slug": "ref",
+    "source": false,
     "children": [
       {
         "label": "pr",
@@ -39,7 +40,7 @@
       },
       {
         "label": "publish",
-        "slug": "pubish"
+        "slug": "publish"
       },
       {
         "label": "runner",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -30,6 +30,36 @@
     "slug": "self-hosted-runners"
   },
   {
+    "label": "Command Reference",
+    "slug": "ref",
+    "children": [
+      {
+        "label": "pr",
+        "slug": "pr"
+      },
+      {
+        "label": "publish",
+        "slug": "pubish"
+      },
+      {
+        "label": "runner",
+        "slug": "runner"
+      },
+      {
+        "label": "send-comment",
+        "slug": "send-comment"
+      },
+      {
+        "label": "send-github-check",
+        "slug": "send-github-check"
+      },
+      {
+        "label": "tensorboard-dev",
+        "slug": "tensorboard-dev"
+      }
+    ]
+  },
+  {
     "label": "Install as a Package",
     "slug": "cml-with-npm"
   },


### PR DESCRIPTION
Just stub pages with a little description for now. The idea (for now) is *not* to duplicate `cml {cmd} --help` output but instead provide examples, edge cases, warnings, etc.

- part of #55
- part of https://github.com/iterative/cml/issues/514