### PR TITLE
cml subcommands & ref improvements

### DIFF
--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -33,30 +33,30 @@ jobs:
           dvc repro
 
           # Report metrics
-          echo "## Metrics" >> myreport.md
+          echo "## Metrics" >> report.md
           git fetch --prune
-          dvc metrics diff master --show-md >> myreport.md
+          dvc metrics diff master --show-md >> report.md
 
           # Publish confusion matrix diff
-          echo "## Plots" >> myreport.md
-          echo "### Class confusions" >> myreport.md
+          echo "## Plots" >> report.md
+          echo "### Class confusions" >> report.md
           dvc plots diff \
             --target classes.csv \
             --template confusion \
             -x actual \
             -y predicted \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 | cml publish --md >> myreport.md
+          vl2png vega.json -s 1.5 | cml publish --md >> report.md
 
           # Publish regularization function diff
-          echo "### Effects of regularization" >> myreport.md
+          echo "### Effects of regularization" >> report.md
           dvc plots diff \
             --target estimators.csv \
             -x Regularization \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 | cml publish --md >> myreport.md
+          vl2png vega.json -s 1.5 | cml publish --md >> report.md
 
-          cml send-comment myreport.md
+          cml send-comment report.md
 ```
 
 ## Cloud Storage Provider Credentials

--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -138,7 +138,7 @@ env:
 ## For GitHub Actions Users: Try the `setup-dvc` Action!
 
 The [iterative/setup-dvc](https://github.com/iterative/setup-dvc) action is a
-JavaScript action that sets up [DVC](https://dvc.org/) in your workflow.
+JavaScript action that sets up [DVC](https://dvc.org) in your workflow.
 
 ### Usage
 

--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -33,29 +33,30 @@ jobs:
           dvc repro
 
           # Report metrics
-          echo "## Metrics" >> report.md
+          echo "## Metrics" >> myreport.md
           git fetch --prune
-          dvc metrics diff master --show-md >> report.md
+          dvc metrics diff master --show-md >> myreport.md
 
           # Publish confusion matrix diff
-          echo -e "## Plots\n### Class confusions" >> report.md
+          echo "## Plots" >> myreport.md
+          echo "### Class confusions" >> myreport.md
           dvc plots diff \
             --target classes.csv \
             --template confusion \
             -x actual \
             -y predicted \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 | cml publish --md >> report.md
+          vl2png vega.json -s 1.5 | cml publish --md >> myreport.md
 
           # Publish regularization function diff
-          echo "### Effects of regularization\n" >> report.md
+          echo "### Effects of regularization" >> myreport.md
           dvc plots diff \
             --target estimators.csv \
             -x Regularization \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 | cml publish --md >> report.md
+          vl2png vega.json -s 1.5 | cml publish --md >> myreport.md
 
-          cml send-comment report.md
+          cml send-comment myreport.md
 ```
 
 ## Cloud Storage Provider Credentials

--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -45,7 +45,7 @@ jobs:
             -x actual \
             -y predicted \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 | cml-publish --md >> report.md
+          vl2png vega.json -s 1.5 | cml publish --md >> report.md
 
           # Publish regularization function diff
           echo "### Effects of regularization\n" >> report.md
@@ -53,9 +53,9 @@ jobs:
             --target estimators.csv \
             -x Regularization \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 | cml-publish --md >> report.md
+          vl2png vega.json -s 1.5 | cml publish --md >> report.md
 
-          cml-send-comment report.md
+          cml send-comment report.md
 ```
 
 ## Cloud Storage Provider Credentials

--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -43,16 +43,16 @@ contributing!
 
 Get the latest development version. [Fork] and clone the repo:
 
-```dvc
-$ git clone git@github.com:<your-username>/cml.git
+```bash
+git clone git@github.com:<your-username>/cml.git
 ```
 
 Ensure that you have NodeJS 12.x or 14.x installed. Install coding style
 pre-commit hooks with:
 
-```dvc
-$ cd cml
-$ npm install
+```bash
+cd cml
+npm install
 ```
 
 That's it. You should be ready to make changes, run tests, and make commits! If

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -11,20 +11,34 @@ is roughly equivalent to:
 ```bash
 SHA="$(git log -n1 --format=%h)"
 BASE="$(git branch)"
-git checkout -b "${BASE}-cml-pr-${SHA}"
-find . -name "*.py" -o -name "*.json" | xargs git add
-git commit -m "CML PR for ${SHA} [skip ci]"
-git push
-curl \
-  -X POST \
-  -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls \
-  -d "{
-    \"head\": \"${BASE}-cml-pr-${SHA}\",
-    \"base\": \"${BASE}\",
-    \"title\": \"CML PR for ${BASE} ${SHA}\",
-    \"description\":
-      \"Automated commits for ${GITHUB_REPOSITORY}/commit/${SHA} created by CML.\"
-  }" \
-  | jq -r .url
+
+git checkout "${BASE}-cml-pr-${SHA}" &&
+
+if [[ $(git ls-remote --exit-code origin\
+        "${BASE}-cml-pr-${SHA}" &>/dev/null) ]]; then
+  # branch already exists; just print its PR URL
+  curl \
+    -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls \
+    | jq -r ".[] | select(.head.ref == '${BASE}-cml-pr-${SHA}') | .url"
+else
+  # create branch & PR
+  git checkout -b "${BASE}-cml-pr-${SHA}"
+  git add "**/*.py" "**/*.json"
+  git commit -m "CML PR for ${SHA} [skip ci]"
+  git push
+  curl \
+    -X POST \
+    -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls \
+    -d "{
+      \"head\": \"${BASE}-cml-pr-${SHA}\",
+      \"base\": \"${BASE}\",
+      \"title\": \"CML PR for ${BASE} ${SHA}\",
+      \"description\":
+        \"Automated commits for\
+          ${GITHUB_REPOSITORY}/commit/${SHA} created by CML.\"
+    }" \
+    | jq -r .url
+fi
 ```

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -2,13 +2,13 @@
 
 Commit specified files to a new branch and create a pull request.
 
-```dvc
-cml pr '**/*.py' '**/*.json'
+```bash
+cml pr "**/*.py" "**/*.json"
 ```
 
 is roughly equivalent to:
 
-```dvc
+```bash
 SHA="$(git log -n1 --format=%h)"
 BASE="$(git branch)"
 git checkout -b "${BASE}-cml-pr-${SHA}"

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -12,8 +12,19 @@ is roughly equivalent to:
 SHA="$(git log -n1 --format=%h)"
 BASE="$(git branch)"
 git checkout -b "${BASE}-cml-pr-${SHA}"
-git add *.py *.json
+find . -name '*.py' -o -name '*.json' | xargs git add
 git commit -m "CML PR for ${SHA} [skip ci]"
 git push
-gh pr create -B ${BASE}
+curl \
+  -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls \
+  -d "{
+    \"head\": \"${BASE}-cml-pr-${SHA}\",
+    \"base\": \"${BASE}\",
+    \"title\": \"CML PR for ${BASE} ${SHA}\",
+    \"description\":
+      \"Automated commits for ${GITHUB_REPOSITORY}/commit/${SHA} created by CML.\"
+  }" \
+  | jq -r .url
 ```

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -12,7 +12,7 @@ is roughly equivalent to:
 SHA="$(git log -n1 --format=%h)"
 BASE="$(git branch)"
 git checkout -b "${BASE}-cml-pr-${SHA}"
-find . -name '*.py' -o -name '*.json' | xargs git add
+find . -name "*.py" -o -name "*.json" | xargs git add
 git commit -m "CML PR for ${SHA} [skip ci]"
 git push
 curl \

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -1,9 +1,9 @@
 # Command Reference: `publish`
 
-Publish an image for inclusion in a CML report.
+Publicly host an image for displaying in a CML report.
 
 To render an image in a markdown file:
 
-```dvc
-cml publish --md ./some-image.png >> report.md
+```bash
+cml publish ./myimage.png --md >> myreport.md
 ```

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -5,5 +5,5 @@ Publicly host an image for displaying in a CML report.
 To render an image in a markdown file:
 
 ```bash
-cml publish ./myimage.png --md >> myreport.md
+cml publish ./plot.png --md >> report.md
 ```

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -1,7 +1,9 @@
 # Command Reference: `send-comment`
 
-```dvc
-cml send-comment some_content.md
+Post a markdown comment on a commit.
+
+```bash
+cml send-comment ./myreport.md
 ```
 
 ## Common error messages

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -3,7 +3,7 @@
 Post a markdown comment on a commit.
 
 ```bash
-cml send-comment ./myreport.md
+cml send-comment ./report.md
 ```
 
 ## Common error messages

--- a/content/docs/ref/send-github-check.md
+++ b/content/docs/ref/send-github-check.md
@@ -4,5 +4,5 @@ Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
 [checks interface](https://docs.github.com/en/rest/reference/checks).
 
 ```bash
-cml send-github-check ./myreport.md
+cml send-github-check ./report.md
 ```

--- a/content/docs/ref/send-github-check.md
+++ b/content/docs/ref/send-github-check.md
@@ -3,6 +3,6 @@
 Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
 [checks interface](https://docs.github.com/en/rest/reference/checks).
 
-```dvc
-cml send-github-check some_content.md
+```bash
+cml send-github-check ./myreport.md
 ```

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -2,6 +2,6 @@
 
 Return a link to a <https://tensorboard.dev> page.
 
-```dvc
-cml tensorboard-dev
+```bash
+cml tensorboard-dev --logdir=./logs --title=Training --md >> myreport.md
 ```

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -3,5 +3,5 @@
 Return a link to a <https://tensorboard.dev> page.
 
 ```bash
-cml tensorboard-dev --logdir=./logs --title=Training --md >> myreport.md
+cml tensorboard-dev --logdir=./logs --title=Training --md >> report.md
 ```

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -67,8 +67,8 @@ jobs:
           pip install -r requirements.txt
           python train.py
 
-          cat metrics.txt > report.md
-          cml send-comment report.md
+          cat metrics.txt >> myreport.md
+          cml send-comment myreport.md
 ```
 
 In the workflow above, the `deploy-runner` step launches an EC2 `p2.xlarge`

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -13,7 +13,7 @@ self-hosted runner.
 ## Allocating Cloud Compute Resources with CML
 
 When a workflow requires computational resources (such as GPUs), CML can
-automatically allocate cloud instances using `cml-runner`. You can spin up
+automatically allocate cloud instances using `cml runner`. You can spin up
 instances on [AWS](#aws), [Azure](#azure), [GCP](#gcp), or
 [Kubernetes](#kubernetes).
 
@@ -22,11 +22,11 @@ and trains a model on the instance. After the job runs, the instance
 automatically shuts down.
 
 You might notice that this workflow is quite similar to the
-[basic use case](/doc/usage). The only addition is `cml-runner` and a few
+[basic use case](/doc/usage). The only addition is `cml runner` and a few
 environment variables for passing your cloud compute credentials to the
 workflow.
 
-Note that `cml-runner` will also automatically restart your jobs (whether from a
+Note that `cml runner` will also automatically restart your jobs (whether from a
 [GitHub Actions 72-hour timeout](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners#usage-limits)
 or a
 [AWS EC2 spot instance interruption](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html)).
@@ -46,7 +46,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          cml-runner \
+          cml runner \
               --cloud=aws \
               --cloud-region=us-west \
               --cloud-type=p2.xlarge \
@@ -68,7 +68,7 @@ jobs:
           python train.py
 
           cat metrics.txt > report.md
-          cml-send-comment report.md
+          cml send-comment report.md
 ```
 
 In the workflow above, the `deploy-runner` step launches an EC2 `p2.xlarge`
@@ -76,8 +76,8 @@ instance in the `us-west` region. The `train-model` job then runs on the
 newly-launched instance. See [Environment Variables](#environment-variables)
 below for details on the `secrets` required.
 
-🎉 **Note that jobs can use any Docker container!** To use functions such as
-`cml-send-comment` from a job, the only requirement is to
+🎉 **Note that jobs can use any Docker container!** To use commands such as
+`cml send-comment` from a job, the only requirement is to
 [have CML installed](/doc/cml-with-npm).
 
 ## Docker Images
@@ -98,7 +98,7 @@ For example, `docker://iterativeai/cml:0-dvc2-base1-gpu`, or
 
 ## Options
 
-The `cml-runner` function accepts the following arguments:
+The `cml runner` command accepts the following arguments:
 
 ```
 --help                      Show help                                [boolean]
@@ -279,12 +279,12 @@ provisioned through environment variables instead of files.
 
 #### On-premise (Local) Runners
 
-The `cml-runner` command can also be used to set up a local machine or
+The `cml runner` command can also be used to set up a local machine or
 on-premise GPU cluster as a self-hosted runner. Simply
 [install CML with NPM](/doc/cml-with-npm) and then run:
 
 ```
-cml-runner \
+cml runner \
   --repo="$REPOSITORY_URL" \
   --token="$PERSONAL_ACCESS_TOKEN" \
   --labels="local,runner" \

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -283,7 +283,7 @@ The `cml runner` command can also be used to set up a local machine or
 on-premise GPU cluster as a self-hosted runner. Simply
 [install CML with NPM](/doc/cml-with-npm) and then run:
 
-```
+```bash
 cml runner \
   --repo="$REPOSITORY_URL" \
   --token="$PERSONAL_ACCESS_TOKEN" \
@@ -297,7 +297,7 @@ The machine will listen for jobs from your repository and execute them locally.
 ones) may be able to execute arbitrary code on your machine. Refer to the
 corresponding
 [GitHub](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners)
-and [GitLab](https://docs.gitlab.com/runner/security/) documentation for
+and [GitLab](https://docs.gitlab.com/runner/security) documentation for
 additional guidance.
 
 </details>

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -67,8 +67,8 @@ jobs:
           pip install -r requirements.txt
           python train.py
 
-          cat metrics.txt >> myreport.md
-          cml send-comment myreport.md
+          cat metrics.txt >> report.md
+          cml send-comment report.md
 ```
 
 In the workflow above, the `deploy-runner` step launches an EC2 `p2.xlarge`

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -36,9 +36,9 @@ supported CI systems.
                   pip install -r requirements.txt
                   python train.py
 
-                  cat metrics.txt >> report.md
-                  cml publish confusion_matrix.png --md >> report.md
-                  cml send-comment report.md
+                  cat metrics.txt >> myreport.md
+                  cml publish confusion_matrix.png --md >> myreport.md
+                  cml send-comment myreport.md
    ```
 
 3. In your text editor of choice, edit line 16 of `train.py` to `depth = 5`.
@@ -141,7 +141,7 @@ steps:
       # train will generate plot.png
       python train.py
 
-      echo 'My first CML report' > report.md
-      cml publish plot.png --md > report.md
-      cml send-comment report.md
+      echo "# My first CML report" >> myreport.md
+      cml publish plot.png --md >> myreport.md
+      cml send-comment myreport.md
 ```

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -66,20 +66,20 @@ This is the gist of the CML workflow: when you push changes to your GitHub
 repository, the workflow in your `.github/workflows/cml.yaml` file gets run and
 a report generated.
 
-CML functions let you display relevant results from the workflow, like model
+CML commands let you display relevant results from the workflow, like model
 performance metrics and vizualizations, in GitHub checks and comments. What kind
 of workflow you want to run, and want to put in your CML report, is up to you.
 
 ## The CML GitHub Action
 
-In the above example, we got the CML functions thanks to our Docker container.
+In the above example, we got the CML commands thanks to our Docker container.
 But there's another way for GitHub Actions users to get CML: the `setup-cml`
 Action!
 
 The [iterative/setup-cml](https://github.com/iterative/setup-cml) action is a
-JavaScript workflow that provides [CML](https://cml.dev/) functions in your
-GitHub Actions workflow. The action allows users to install CML without using
-the CML Docker container.
+JavaScript workflow that provides [CML](https://cml.dev) commands in your GitHub
+Actions workflow. The action allows users to install CML without using the CML
+Docker container.
 
 This action gives you:
 
@@ -119,8 +119,8 @@ steps:
 
 The following inputs are supported.
 
-- `version` - (optional) The version of CML to install. A value of `latest` will
-  install the latest version of CML functions. Defaults to `latest`.
+- `version` - (optional) The version of CML to install. The default value of
+  `latest` will install the latest version of CML.
 
 ## Outputs
 

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -129,7 +129,7 @@ Setup CML has no outputs.
 ### A complete workflow
 
 Assume that we have a machine learning script, `train.py`, that outputs an image
-`plot.png`. A potential workflow will look like this:
+`myimage.png`. A potential workflow will look like this:
 
 ```yaml
 steps:
@@ -142,6 +142,6 @@ steps:
       python train.py
 
       echo "# My first CML report" >> myreport.md
-      cml publish plot.png --md >> myreport.md
+      cml publish myimage.png --md >> myreport.md
       cml send-comment myreport.md
 ```

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -36,9 +36,9 @@ supported CI systems.
                   pip install -r requirements.txt
                   python train.py
 
-                  cat metrics.txt >> myreport.md
-                  cml publish confusion_matrix.png --md >> myreport.md
-                  cml send-comment myreport.md
+                  cat metrics.txt >> report.md
+                  cml publish confusion_matrix.png --md >> report.md
+                  cml send-comment report.md
    ```
 
 3. In your text editor of choice, edit line 16 of `train.py` to `depth = 5`.
@@ -129,7 +129,7 @@ Setup CML has no outputs.
 ### A complete workflow
 
 Assume that we have a machine learning script, `train.py`, that outputs an image
-`myimage.png`. A potential workflow will look like this:
+`plot.png`. A potential workflow will look like this:
 
 ```yaml
 steps:
@@ -141,7 +141,7 @@ steps:
       # train will generate plot.png
       python train.py
 
-      echo "# My first CML report" >> myreport.md
-      cml publish myimage.png --md >> myreport.md
-      cml send-comment myreport.md
+      echo "# My first CML report" >> report.md
+      cml publish plot.png --md >> report.md
+      cml send-comment report.md
 ```

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -37,8 +37,8 @@ supported CI systems.
                   python train.py
 
                   cat metrics.txt >> report.md
-                  cml-publish confusion_matrix.png --md >> report.md
-                  cml-send-comment report.md
+                  cml publish confusion_matrix.png --md >> report.md
+                  cml send-comment report.md
    ```
 
 3. In your text editor of choice, edit line 16 of `train.py` to `depth = 5`.
@@ -57,8 +57,8 @@ supported CI systems.
    ![](/img/make_pr.png)
 
    Shortly, you should see a comment from `github-actions` appear in the Pull
-   Request with your CML report. This is a result of the function
-   `cml-send-comment` in your workflow.
+   Request with your CML report. This is a result of the `cml send-comment`
+   command in your workflow.
 
    ![](/img/cml_first_report.png)
 
@@ -83,9 +83,9 @@ the CML Docker container.
 
 This action gives you:
 
-- Functions like `cml-publish` and `cml-send-comment` for publishing data
+- Commands like `cml publish` and `cml send-comment` for publishing data
   visualization and metrics from your CI workflow as comments in a pull request.
-- `cml-runner`, a function that enables workflows to provision cloud and
+- `cml runner`, a command that enables workflows to provision cloud and
   on-premise computing resources for training models
 - The freedom 🦅 to mix and match CML with your favorite data science tools and
   environments
@@ -142,6 +142,6 @@ steps:
       python train.py
 
       echo 'My first CML report' > report.md
-      cml-publish plot.png --md > report.md
-      cml-send-comment report.md
+      cml publish plot.png --md > report.md
+      cml send-comment report.md
 ```

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -71,9 +71,9 @@ Here, we'll walk through a tutorial to start using CML on GitLab.
        - pip3 install -r requirements.txt
        - python train.py
 
-       - cat metrics.txt >> myreport.md
-       - cml publish confusion_matrix.png --md >> myreport.md
-       - cml send-comment myreport.md
+       - cat metrics.txt >> report.md
+       - cml publish confusion_matrix.png --md >> report.md
+       - cml send-comment report.md
    ```
 
 6. In your text editor, open `train.py` and edit line 16 to `depth = 5`.

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -72,8 +72,8 @@ Here, we'll walk through a tutorial to start using CML on GitLab.
        - python train.py
 
        - cat metrics.txt >> report.md
-       - cml-publish confusion_matrix.png --md >> report.md
-       - cml-send-comment report.md
+       - cml publish confusion_matrix.png --md >> report.md
+       - cml send-comment report.md
    ```
 
 6. In your text editor, open `train.py` and edit line 16 to `depth = 5`.
@@ -104,6 +104,6 @@ Here, we'll walk through a tutorial to start using CML on GitLab.
     comments you would like to put in the description and click the "Submit
     merge request" button. Shortly, you should see a comment from GitLab CI
     appear in the Pull Request with your CML report. This is a result of the
-    function cml-send-comment in your workflow.
+    function `cml send-comment` in your workflow.
 
     ![](/img/cml_start_gitlab_end.png)

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -71,9 +71,9 @@ Here, we'll walk through a tutorial to start using CML on GitLab.
        - pip3 install -r requirements.txt
        - python train.py
 
-       - cat metrics.txt >> report.md
-       - cml publish confusion_matrix.png --md >> report.md
-       - cml send-comment report.md
+       - cat metrics.txt >> myreport.md
+       - cml publish confusion_matrix.png --md >> myreport.md
+       - cml send-comment myreport.md
    ```
 
 6. In your text editor, open `train.py` and edit line 16 to `depth = 5`.

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -104,6 +104,6 @@ Here, we'll walk through a tutorial to start using CML on GitLab.
     comments you would like to put in the description and click the "Submit
     merge request" button. Shortly, you should see a comment from GitLab CI
     appear in the Pull Request with your CML report. This is a result of the
-    function `cml send-comment` in your workflow.
+    `cml send-comment` command in your workflow.
 
     ![](/img/cml_start_gitlab_end.png)

--- a/content/docs/start/index.md
+++ b/content/docs/start/index.md
@@ -15,7 +15,7 @@ results and metrics. Above, an example report for a
 
 We built CML with these principles in mind:
 
-- **[GitFlow](https://nvie.com/posts/a-successful-git-branching-model/) for data
+- **[GitFlow](https://nvie.com/posts/a-successful-git-branching-model) for data
   science.** Use GitLab or GitHub to manage ML experiments, track who trained ML
   models or modified data and when. Codify data and models with
   [DVC](/doc/cml-with-dvc) instead of pushing to a Git repo.

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -51,8 +51,8 @@ jobs:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Post reports as comments in GitHub PRs
-          cat results.txt >> myreport.md
-          cml send-comment myreport.md
+          cat results.txt >> report.md
+          cml send-comment report.md
 ```
 
 We helpfully provide CML and other useful libraries pre-installed on our
@@ -77,23 +77,23 @@ e.g. `cml runner --cloud={aws,azure,gcp,kubernetes} ...`
 
 ∞ **[`publish`](/doc/ref/publish)**\
 Publicly host an image for displaying in a CML report\
-e.g. `cml publish myimage.png --md >> myreport.md`
+e.g. `cml publish plot.png --md >> report.md`
 
 ∞ **[`pr`](/doc/ref/pr)**\
 Commit specified files to a new branch and create a pull request\
-e.g. `cml pr "**/*.json" "**/*.py" --md >> myreport.md`
+e.g. `cml pr "**/*.json" "**/*.py" --md >> report.md`
 
 ∞ **[`send-comment`](/doc/ref/send-comment)**\
 Post a markdown report as a commit comment\
-e.g. `cml send-comment myreport.md`
+e.g. `cml send-comment report.md`
 
 ∞ **[`send-github-check`](/doc/ref/send-github-check)**\
 Post a markdown report as a GitHub check\
-e.g. `cml send-github-check myreport.md`
+e.g. `cml send-github-check report.md`
 
 ∞ **[`tensorboard-dev`](/doc/ref/tensorboard-dev)**\
 Return a link to a <https://tensorboard.dev> page\
-e.g. `cml tensorboard-dev --logdir=./logs --md >> myreport.md`
+e.g. `cml tensorboard-dev --logdir=./logs --md >> report.md`
 
 ### CML Reports
 
@@ -109,14 +109,14 @@ you. Some examples:
 copy the contents of a text file containing the results of ML model training:
 
 ```bash
-cat results.txt >> myreport.md
+cat results.txt >> report.md
 ```
 
 🖼️ **Images** Display images using the markdown or HTML. Note that if an image
 is an output of your ML workflow (i.e., it is produced by your workflow), you
 will need to use the `cml publish` command to include it a CML report. For
-example, if `myimage.png` is output by `python train.py`, run:
+example, if `plot.png` is output by `python train.py`, run:
 
 ```bash
-cml publish myimage.png --md >> myreport.md
+cml publish plot.png --md >> report.md
 ```

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -62,14 +62,14 @@ example, uncommenting the
 runner pull the CML Docker image. The image already has NodeJS, Python 3, DVC
 and CML set up on an Ubuntu LTS base for convenience.
 
-## CML Functions
+## CML Commands
 
-CML provides a number of functions to help package the outputs of ML workflows
+CML provides a number of commands to help package the outputs of ML workflows
 (including numeric data and visualizations about model performance) into a CML
 report.
 
-Below is a table of CML functions for writing markdown reports and delivering
-those reports to your CI system.
+Below is a table of CML commands for starting cloud compute runners, writing and
+publishing markdown reports to your CI/CD system.
 
 | Command                                               | Description                                                                                                                    | Example Input                               |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
@@ -99,7 +99,7 @@ cat results.txt >> report.md
 
 🖼️ **Images** Display images using the markdown or HTML. Note that if an image
 is an output of your ML workflow (i.e., it is produced by your workflow), you
-will need to use the `cml publish` function to include it a CML report. For
+will need to use the `cml publish` command to include it a CML report. For
 example, if `graph.png` is output by `python train.py`, run:
 
 ```bash

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -51,8 +51,8 @@ jobs:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Post reports as comments in GitHub PRs
-          cat results.txt >> report.md
-          cml send-comment report.md
+          cat results.txt >> myreport.md
+          cml send-comment myreport.md
 ```
 
 We helpfully provide CML and other useful libraries pre-installed on our
@@ -109,14 +109,14 @@ you. Some examples:
 copy the contents of a text file containing the results of ML model training:
 
 ```bash
-cat results.txt >> report.md
+cat results.txt >> myreport.md
 ```
 
 🖼️ **Images** Display images using the markdown or HTML. Note that if an image
 is an output of your ML workflow (i.e., it is produced by your workflow), you
 will need to use the `cml publish` command to include it a CML report. For
-example, if `graph.png` is output by `python train.py`, run:
+example, if `myimage.png` is output by `python train.py`, run:
 
 ```bash
-cml publish graph.png --md >> report.md
+cml publish myimage.png --md >> myreport.md
 ```

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -68,17 +68,32 @@ CML provides a number of commands to help package the outputs of ML workflows
 (including numeric data and visualizations about model performance) into a CML
 report.
 
-Below is a table of CML commands for starting cloud compute runners, writing and
+Below is a list of CML commands for starting cloud compute runners, writing and
 publishing markdown reports to your CI/CD system.
 
-| Command                                               | Description                                                                                                                    | Example Input                               |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
-| [`cml runner`](/doc/ref/runner)                       | Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners)) | `--cloud={aws,azure,gcp,kubernetes} ...`    |
-| [`cml publish`](/doc/ref/publish)                     | Publicly host an image for displaying in a CML report                                                                          | `myimage.png --md >> myreport.md`           |
-| [`cml send-comment`](/doc/ref/send-comment)           | Post a markdown report as a commit comment                                                                                     | `myreport.md`                               |
-| [`cml send-github-check`](/doc/ref/send-github-check) | Post a markdown report as a GitHub check                                                                                       | `myreport.md`                               |
-| [`cml pr`](/doc/ref/pr)                               | Commit specified files to a new branch and create a pull request                                                               | `"**/*.json" "**/*.py" --md >> myreport.md` |
-| [`cml tensorboard-dev`](/doc/ref/tensorboard-dev)     | Return a link to a <https://tensorboard.dev> page                                                                              | `--logdir=./logs --md >> myreport.md`       |
+∞ **[`runner`](/doc/ref/runner)**\
+Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners))\
+e.g. `cml runner --cloud={aws,azure,gcp,kubernetes} ...`
+
+∞ **[`publish`](/doc/ref/publish)**\
+Publicly host an image for displaying in a CML report\
+e.g. `cml publish myimage.png --md >> myreport.md`
+
+∞ **[`pr`](/doc/ref/pr)**\
+Commit specified files to a new branch and create a pull request\
+e.g. `cml pr "**/*.json" "**/*.py" --md >> myreport.md`
+
+∞ **[`send-comment`](/doc/ref/send-comment)**\
+Post a markdown report as a commit comment\
+e.g. `cml send-comment myreport.md`
+
+∞ **[`send-github-check`](/doc/ref/send-github-check)**\
+Post a markdown report as a GitHub check\
+e.g. `cml send-github-check myreport.md`
+
+∞ **[`tensorboard-dev`](/doc/ref/tensorboard-dev)**\
+Return a link to a <https://tensorboard.dev> page\
+e.g. `cml tensorboard-dev --logdir=./logs --md >> myreport.md`
 
 ### CML Reports
 

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -52,7 +52,7 @@ jobs:
         run: |
           # Post reports as comments in GitHub PRs
           cat results.txt >> report.md
-          cml-send-comment report.md
+          cml send-comment report.md
 ```
 
 We helpfully provide CML and other useful libraries pre-installed on our
@@ -71,18 +71,18 @@ report.
 Below is a table of CML functions for writing markdown reports and delivering
 those reports to your CI system.
 
-| Function                | Description                                                      | Example Inputs                                              |
-| ----------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
-| `cml-runner`            | Launch a runner locally or hosted by a cloud provider            | See [Arguments](https://github.com/iterative/cml#arguments) |
-| `cml-publish`           | Publicly host an image for displaying in a CML report            | `<path to image> --title <image title> --md`                |
-| `cml-send-comment`      | Return CML report as a comment in your GitLab/GitHub workflow    | `<path to report> --head-sha <sha>`                         |
-| `cml-send-github-check` | Return CML report as a check in GitHub                           | `<path to report> --head-sha <sha>`                         |
-| `cml-pr`                | Commit the given files to a new branch and create a pull request | `<path>...`                                                 |
-| `cml-tensorboard-dev`   | Return a link to a Tensorboard.dev page                          | `--logdir <path to logs> --title <experiment title> --md`   |
+| Command                                               | Description                                                                                                                    | Example Input                               |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| [`cml runner`](/doc/ref/runner)                       | Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners)) | `--cloud={aws,azure,gcp,kubernetes} ...`    |
+| [`cml publish`](/doc/ref/publish)                     | Publicly host an image for displaying in a CML report                                                                          | `myimage.png --md >> myreport.md`           |
+| [`cml send-comment`](/doc/ref/send-comment)           | Post a markdown report as a commit comment                                                                                     | `myreport.md`                               |
+| [`cml send-github-check`](/doc/ref/send-github-check) | Post a markdown report as a GitHub check                                                                                       | `myreport.md`                               |
+| [`cml pr`](/doc/ref/pr)                               | Commit specified files to a new branch and create a pull request                                                               | `"**/*.json" "**/*.py" --md >> myreport.md` |
+| [`cml tensorboard-dev`](/doc/ref/tensorboard-dev)     | Return a link to a <https://tensorboard.dev> page                                                                              | `--logdir=./logs --md >> myreport.md`       |
 
 ### CML Reports
 
-The `cml-send-comment` command can be used to post reports. CML reports are
+The `cml send-comment` command can be used to post reports. CML reports are
 written in markdown ([GitHub](https://github.github.com/gfm),
 [GitLab](https://docs.gitlab.com/ee/user/markdown.html), or
 [Bitbucket](https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html)
@@ -99,9 +99,9 @@ cat results.txt >> report.md
 
 🖼️ **Images** Display images using the markdown or HTML. Note that if an image
 is an output of your ML workflow (i.e., it is produced by your workflow), you
-will need to use the `cml-publish` function to include it a CML report. For
+will need to use the `cml publish` function to include it a CML report. For
 example, if `graph.png` is output by `python train.py`, run:
 
 ```bash
-cml-publish graph.png --md >> report.md
+cml publish graph.png --md >> report.md
 ```

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -184,8 +184,8 @@ cml:
   script: <Tooltip type="dependencies"> - pip3 install -r requirements.txt -
     python train.py </Tooltip>
 
-    <Tooltip type="reports"> - cat metrics.txt >> report.md - cml-publish
-    confusion_matrix.png --md >> report.md - cml-send-comment report.md
+    <Tooltip type="reports"> - cat metrics.txt >> report.md - cml publish
+    confusion_matrix.png --md >> report.md - cml send-comment report.md
     </Tooltip>
 ```
 
@@ -229,8 +229,8 @@ jobs:
 
           <Tooltip type="reports">
           cat metrics.txt >> report.md
-          cml-publish confusion_matrix.png --md >> report.md
-          cml-send-comment report.md
+          cml publish confusion_matrix.png --md >> report.md
+          cml send-comment report.md
           </Tooltip>
 ```
 
@@ -277,8 +277,8 @@ cml:
     - dvc plots diff
       --target loss.csv --show-vega master > vega.json
     <Tooltip type="reports">
-    - vl2png vega.json | cml-publish --md >> report.md
-    - cml-send-comment report.md
+    - vl2png vega.json | cml publish --md >> report.md
+    - cml send-comment report.md
     </Tooltip>
 ```
 
@@ -338,8 +338,8 @@ jobs:
           dvc plots diff \
             --target loss.csv --show-vega master > vega.json
           <Tooltip type="reports">
-          vl2png vega.json -s 1.5 | cml-publish --md  >> report.md
-          cml-send-comment report.md
+          vl2png vega.json -s 1.5 | cml publish --md >> report.md
+          cml send-comment report.md
           </Tooltip>
 ```
 
@@ -371,13 +371,13 @@ cml:
     script:
         - pip install -r requirements.txt
         <Tooltip type="tensorboard">
-        - cml-tensorboard-dev \
+        - cml tensorboard-dev \
             --logdir logs \
             --name "Go to tensorboard" \
             --md >> report.md
         </Tooltip>
         <Tooltip type="reports">
-        - cml-send-comment report.md
+        - cml send-comment report.md
         </Tooltip>
 
         <Tooltip type="dependencies">
@@ -425,13 +425,13 @@ jobs:
           pip install -r requirements.txt
 
           <Tooltip type="tensorboard">
-          cml-tensorboard-dev \
+          cml tensorboard-dev \
             --logdir logs \
             --name "Go to tensorboard" \
             --md >> report.md
           </Tooltip>
           <Tooltip type="reports">
-          cml-send-comment report.md
+          cml send-comment report.md
           </Tooltip>
 
           <Tooltip type="dependencies">
@@ -469,7 +469,7 @@ deploy_job:
   image: dvcorg/cml
   script:
     <Tooltip type="reports">
-    - cml-runner
+    - cml runner
       --cloud=aws
       --cloud-region=us-west
       --cloud-type=t2.micro
@@ -491,8 +491,8 @@ train_job:
 
     - echo "## Report from your EC2 Instance" > report.md
     - cat metrics.txt >> report.md
-    - cml-publish "confusion_matrix.png" --md >> report.md
-    - cml-send-comment report.md
+    - cml publish confusion_matrix.png --md >> report.md
+    - cml send-comment report.md
 
 ```
 
@@ -528,7 +528,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: { "${{ secrets.AWS_SECRET_ACCESS_KEY }}" }
         run: |
           <Tooltip type="reports">
-          cml-runner \
+          cml runner \
           --cloud=aws \
           --cloud-region=us-west \
           --cloud-type=t2.micro \
@@ -555,8 +555,8 @@ jobs:
 
         echo "## Report from your EC2 Instance" > report.md
         cat metrics.txt >> report.md
-        cml-publish "confusion_matrix.png" --md >> report.md
-        cml-send-comment report.md
+        cml publish confusion_matrix.png --md >> report.md
+        cml send-comment report.md
 ```
 
 <ExampleBox title="CML Report">
@@ -589,7 +589,7 @@ deploy_job:
   image: dvcorg/cml
   script:
     <Tooltip type="reports">
-    - cml-runner \
+    - cml runner \
       --cloud=aws \
       --cloud-region=us-west \
       --cloud-type=g3.4xlarge \
@@ -622,7 +622,7 @@ train_job:
     - convert +append final_owl.png master_owl.png out.png
     - convert out.png -resize 75% out_shrink.png
     - echo "### Workspace vs. Master" >> report.md
-    - cml-publish out_shrink.png --md >> report.md
+    - cml publish out_shrink.png --md >> report.md
 
     # Report training parameters
     - echo "## Training parameter diffs" >> report.md
@@ -633,7 +633,7 @@ train_job:
     - echo "## GPU info" >> report.md
     - cat gpu_info.txt >> report.md
 
-    - cml-send-comment report.md
+    - cml send-comment report.md
 
 
 ```
@@ -670,7 +670,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: { "${{ secrets.AWS_SECRET_ACCESS_KEY }}" }
         run: |
           <Tooltip type="reports">
-          cml-runner \
+          cml runner \
           --cloud=aws \
           --cloud-region=us-west \
           --cloud-type=g3.4xlarge \
@@ -713,7 +713,7 @@ jobs:
         convert +append final_owl.png master_owl.png out.png
         convert out.png -resize 75%  out_shrink.png
         echo "### Workspace vs. Main" >> report.md
-        cml-publish out_shrink.png --md --title 'compare' >> report.md
+        cml publish out_shrink.png --md --title 'compare' >> report.md
 
         echo "## Training metrics" >> report.md
         dvc params diff master --show-md >> report.md
@@ -722,7 +722,7 @@ jobs:
         echo "## GPU info" >> report.md
         cat gpu_info.txt >> report.md
 
-        cml-send-comment report.md
+        cml send-comment report.md
 ```
 
 <ExampleBox title="CML Report">


### PR DESCRIPTION
- `cml-subcommand` => `cml subcommand`
- function => command
- `(my)?report.md` => `report.md`
- `(my)?(image|plot|graph).png` => `plot.png`
- fully document `cml pr` behaviour
- unify command ref summaries
- improve code snippet formatting
- minor formatting improvements
- replace command table with list (does it look better? table cell wrapping didn't work well)