### PR TITLE
re-correct example_cml vs cml_base_case

### DIFF
--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -70,7 +70,7 @@ CML commands let you display relevant results from the workflow, like model
 performance metrics and vizualizations, in GitHub checks and comments. What kind
 of workflow you want to run, and want to put in your CML report, is up to you.
 
-## Example
+## Final Solution
 
 An example of what your repository should look like now can be found at
 [iterative/cml_base_case](https://github.com/iterative/cml_base_case).

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -108,7 +108,7 @@ Here, we'll walk through a tutorial to start using CML on GitLab.
 
     ![](/img/cml_start_gitlab_end.png)
 
-## Example
+## Final Solution
 
 An example of what your repository should look like now can be found at
 [iterative.ai/cml-base-case](https://gitlab.com/iterative.ai/cml-base-case).


### PR DESCRIPTION
- adds note linking solution repo
- partially reverts #126 (0ac09b2)