### PR TITLE
GitHub App auth example, ref AWS credentials

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -231,11 +231,12 @@ Use either:
 - a
   [personal access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
   with the `repo` scope, or
-- a
-  [GitHub App](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps)
-  with **Repository permissions / Administration** write permissions (for
-  repository-level runners), or **Organization permissions / Self-hosted
-  runners** write permissions (for organization-level runners).
+- a [GitHub App] with **Repository permissions / Administration** write
+  permissions (for repository-level runners), or **Organization permissions /
+  Self-hosted runners** write permissions (for organization-level runners).
+
+[github app]:
+  https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps
 
 Ideally, you should not use personal access tokens from your own account, as
 they grant access to all your repositories. Instead, it's highly recommended to
@@ -243,6 +244,8 @@ create a separate _bot account_ that only has access to the repositories where
 you plan to deploy runners to. Bot accounts are
 [the same](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#personal-user-accounts)
 as normal user accounts, with the only difference being the intended use case.
+
+#### PAT
 
 For instance, to use a personal access token:
 
@@ -259,6 +262,30 @@ For instance, to use a personal access token:
 
 Step 2 can also be used for adding other secrets such as cloud access
 credentials.
+
+#### App
+
+Alternatively, a [GitHub App] ID (`CML_GITHUB_APP_ID`) and private key
+(`CML_GITHUB_APP_PEM`) can be used to generate a token on-the-fly, as shown in
+the example below:
+
+```yaml
+steps:
+  - uses: navikt/github-app-token-generator@v1
+    id: get-token
+    with:
+      private-key: ${{ secrets.CML_GITHUB_APP_PEM }}
+      app-id: ${{ secrets.CML_GITHUB_APP_ID }}
+  - uses: actions/checkout@v2
+    with:
+      token: ${{ steps.get-token.outputs.token }}
+  - name: Train model
+    env:
+      REPO_TOKEN: ${{ steps.get-token.outputs.token }}
+    run: |
+      ...
+      cml send-comment report.md
+```
 
 </tab>
 <tab title="GitLab">

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -7,8 +7,8 @@ resources, or train in the cloud.
 
 ☝️ **Tip!** Check out the official documentation from
 [GitHub](https://help.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)
-and [GitLab](https://docs.gitlab.com/runner) to get started setting up your
-self-hosted runner.
+and [GitLab](https://docs.gitlab.com/runner) for more information on self-hosted
+runners.
 
 ⚠️ Using
 [self-hosted runners for Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/runners)
@@ -342,7 +342,11 @@ Click below to see credentials needed for supported compute providers.
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_SESSION_TOKEN` **(optional)**
 
-Note that the same credentials can also be used for
+See the
+[AWS credentials docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)
+for obtaining these keys.
+
+☝️ **Note** The same credentials can also be used for
 [configuring cloud storage](/doc/cml-with-dvc#cloud-storage-provider-credentials).
 
 </tab>

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -73,7 +73,7 @@ of workflow you want to run, and want to put in your CML report, is up to you.
 ## Final Solution
 
 An example of what your repository should look like now can be found at
-[iterative/cml_base_case](https://github.com/iterative/cml_base_case).
+[`iterative/cml_base_case`](https://github.com/iterative/cml_base_case).
 
 ## Setup Action
 


### PR DESCRIPTION
- GitHub App auth example (from https://github.com/iterative/cml/issues/800#issuecomment-970291851 @RadionBik)
- (unrelated) link to AWS creds docs
- minor copyediting
