### PR TITLE
ref/pr: add options & examples

### DIFF
--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -37,21 +37,22 @@ under any circumstances.
 cml pr "."
 ```
 
-### Automatically merge P.R. using GitHub API
+### Automatically merge GitHub pull requests
 
 ```yaml
 on: pull_request
 jobs:
-  build:
+  cml:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: iterative/setup-cml@v1
-      - run: |
-          date > file
-          gh pr merge --rebase $(cml pr file)
+      - name: Generate data
+        run: echo "Hello World" > output.txt
+      - name: Create and merge PR
+        run: gh pr merge --rebase $(cml pr "output.txt")
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### Command internals

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -3,8 +3,8 @@
 Commit specified files to a new branch and create a pull request. If sending a
 report afterwards, consider using `cml send-comment --pr --update`.
 
-ⓘ Pull requests created with `cml pr` **won't** trigger a new CI/CD run
-under any circumstances.
+ⓘ Pull requests created with `cml pr` **won't** trigger a new CI/CD run,
+thereby preventing an infinite chain of runs.
 
 ⓘ You can specify the files to track using any syntax supported by [Git pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec).
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -6,7 +6,8 @@ report afterwards, consider using `cml send-comment --pr --update`.
 ⓘ Pull requests created with `cml pr` **won't** trigger a new CI/CD run,
 thereby preventing an infinite chain of runs.
 
-ⓘ You can specify the files to track using any syntax supported by [Git pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec).
+ⓘ Files to commit can be specified using any syntax supported by
+[Git pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec).
 
 ## Options
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -3,8 +3,8 @@
 Commit specified files to a new branch and create a pull request. If sending a
 report afterwards, consider using `cml send-comment --pr --update`.
 
-ⓘ Pull requests created with `cml pr` **won't** trigger a new CI/CD run,
-thereby preventing an infinite chain of runs.
+ⓘ Pull requests created with `cml pr` **won't** trigger a new CI/CD run, thereby
+preventing an infinite chain of runs.
 
 ⓘ Files to commit can be specified using any syntax supported by
 [Git pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec).

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -3,6 +3,59 @@
 Commit specified files to a new branch and create a pull request. If sending a
 report afterwards, consider using `cml send-comment --pr --update`.
 
+ⓘ Pull requests created with `cml pr` **won't** trigger a new CI/CD run
+under any circumstances.
+
+ⓘ You can specify the files to track using any syntax supported by [Git pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec).
+
+## Options
+
+```
+--help                      Show help                                [boolean]
+--version                   Show version number                      [boolean]
+--log                       Maximum log level
+        [string] [choices: "error", "warn", "info", "debug"] [default: "info"]
+--md          Output in markdown format [](url).                    [boolean]
+--remote      Sets git remote.                   [string] [default: "origin"]
+--user-email  Sets git user email.
+                                    [string] [default: "olivaw@iterative.ai"]
+--user-name   Sets git user name.
+                                            [string] [default: "Olivaw[bot]"]
+--repo        Specifies the repo to be used. If not specified is extracted
+              from the CI ENV.                                       [string]
+--token       Personal access token to be used. If not specified in extracted
+              from ENV REPO_TOKEN.                                   [string]
+--driver      If not specify it infers it from the ENV.
+                                       [string] [choices: "github", "gitlab"]
+```
+
+## Examples
+
+### Commit all files in current working directory
+
+```bash
+cml pr "."
+```
+
+### Automatically merge P.R. using GitHub API
+
+```yaml
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: iterative/setup-cml@v1
+      - run: |
+          date > file
+          gh pr merge --rebase $(cml pr file)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+```
+
+### Command internals
+
 ```bash
 cml pr "**/*.py" "**/*.json"
 ```
@@ -43,6 +96,3 @@ else
     | jq -r .url
 fi
 ```
-
-Note: pull requests created with `cml pr` **won't** trigger a new CI/CD run
-under any circumstances.


### PR DESCRIPTION
💅 Just a few things I would find useful (i.e. I had to check for the actual implementation to find out that any pathspec is supported as `git add` is being used)

