### PR TITLE
ref: document all options

### DIFF
--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -2,3 +2,4 @@
 - 'http://localhost:9000**'
 - 'https://dvc.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a'
 - '**linkedin.com/company/**'
+- url

--- a/content/docs/ref/index.md
+++ b/content/docs/ref/index.md
@@ -4,17 +4,14 @@
 
 All CML commands support the following options:
 
-```
---help                      Show help                                [boolean]
---version                   Show version number                      [boolean]
---log                       Maximum log level
-        [string] [choices: "error", "warn", "info", "debug"] [default: "info"]
---driver                    Platform where the repository is hosted. If not
-                            specified, it will be inferred from the
-                            environment [string] [choices: "github", "gitlab"]
---repo                      Repository (or Organization) to be used.
-                            If not specified, it will be inferred from the
-                            environment                               [string]
---token                     Personal access token to be used. If not specified,
-                            it will be inferred from the environment  [string]
-```
+- `--driver=<ci>`: CI provider where the repository is hosted, choices: {github,
+  gitlab, bitbucket} [default: *inferred from environment*].
+- `--repo=<repo or org>`: Repository (or Organization) to be used [default:
+  *inferred from environment*].
+- `--token=<PAT>`:
+  [Personal/project access token](https://cml.dev/doc/self-hosted-runners#personal-access-token)
+  to be used [default: *inferred from environment*].
+- `--help`: Show help.
+- `--log=<level>`: Maximum log level, choices: {error, warn, info, debug}
+  [default: info].
+- `--version`: Show version number.

--- a/content/docs/ref/index.md
+++ b/content/docs/ref/index.md
@@ -1,0 +1,20 @@
+# Command Reference
+
+## Generic Options
+
+All CML commands support the following options:
+
+```
+--help                      Show help                                [boolean]
+--version                   Show version number                      [boolean]
+--log                       Maximum log level
+        [string] [choices: "error", "warn", "info", "debug"] [default: "info"]
+--driver                    Platform where the repository is hosted. If not
+                            specified, it will be inferred from the
+                            environment [string] [choices: "github", "gitlab"]
+--repo                      Repository (or Organization) to be used.
+                            If not specified, it will be inferred from the
+                            environment                               [string]
+--token                     Personal access token to be used. If not specified,
+                            it will be inferred from the environment  [string]
+```

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -1,5 +1,9 @@
 # Command Reference: `pr`
 
+```bash
+cml pr [options] <pathspec>...
+```
+
 Commit specified files to a new branch and create a pull request. If sending a
 report afterwards, consider using `cml send-comment --pr --update`.
 
@@ -12,12 +16,10 @@ preventing an infinite chain of runs.
 ## Options
 
 ```
---md          Output in markdown format [](url).                    [boolean]
---remote      Sets git remote.                   [string] [default: "origin"]
---user-email  Sets git user email.
-                                    [string] [default: "olivaw@iterative.ai"]
---user-name   Sets git user name.
-                                            [string] [default: "Olivaw[bot]"]
+--md          Output in markdown format [](url).                     [boolean]
+--remote      Sets git remote.                    [string] [default: "origin"]
+--user-email  Sets git user email.   [string] [default: "olivaw@iterative.ai"]
+--user-name   Sets git user name.            [string] [default: "Olivaw[bot]"]
 ```
 
 ## Examples

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -15,6 +15,8 @@ preventing an infinite chain of runs.
 
 ## Options
 
+Any [generic option](/doc/ref) in addition to:
+
 ```
 --md          Output in markdown format [](url).                     [boolean]
 --remote      Sets git remote.                    [string] [default: "origin"]

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -12,22 +12,12 @@ preventing an infinite chain of runs.
 ## Options
 
 ```
---help                      Show help                                [boolean]
---version                   Show version number                      [boolean]
---log                       Maximum log level
-        [string] [choices: "error", "warn", "info", "debug"] [default: "info"]
 --md          Output in markdown format [](url).                    [boolean]
 --remote      Sets git remote.                   [string] [default: "origin"]
 --user-email  Sets git user email.
                                     [string] [default: "olivaw@iterative.ai"]
 --user-name   Sets git user name.
                                             [string] [default: "Olivaw[bot]"]
---repo        Specifies the repo to be used. If not specified is extracted
-              from the CI ENV.                                       [string]
---token       Personal access token to be used. If not specified in extracted
-              from ENV REPO_TOKEN.                                   [string]
---driver      If not specify it infers it from the ENV.
-                                       [string] [choices: "github", "gitlab"]
 ```
 
 ## Examples

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -8,6 +8,8 @@ Publicly host an image for displaying in a CML report.
 
 ## Options
 
+Any [generic option](/doc/ref) in addition to:
+
 ```
     --md                        Output in markdown format [title ||
                                 name](url).                          [boolean]

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -1,6 +1,29 @@
 # Command Reference: `publish`
 
+```bash
+cml publish [options] <image file>
+```
+
 Publicly host an image for displaying in a CML report.
+
+## Options
+
+```
+    --md                        Output in markdown format [title ||
+                                name](url).                          [boolean]
+-t, --title                     Markdown title [title](url) or ![](url title).
+                                                                      [string]
+    --native, --gitlab-uploads  Uses driver's native capabilities to upload
+                                assets instead of CML's storage. Currently
+                                only available for GitLab CI.        [boolean]
+    --rm-watermark              Avoid CML watermark.                 [boolean]
+    --mime-type                 Specifies the mime-type. If not set guess it
+                                from the content.                     [string]
+-f, --file                      Append the output to the given file. Create it
+                                if does not exist.                    [string]
+```
+
+## Examples
 
 To render an image in a markdown file:
 

--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -6,10 +6,6 @@ compute provider or locally on-premise).
 ## Options
 
 ```
---help                      Show help                                [boolean]
---version                   Show version number                      [boolean]
---log                       Maximum log level
-        [string] [choices: "error", "warn", "info", "debug"] [default: "info"]
 --labels                    One or more user-defined labels for this runner
                             (delimited with commas)  [string] [default: "cml"]
 --idle-timeout              Seconds to wait for jobs before shutting down. Set
@@ -21,15 +17,6 @@ compute provider or locally on-premise).
 --single                    Exit after running a single job          [boolean]
 --reuse                     Don't launch a new runner if an existing one has
                             the same name or overlapping labels      [boolean]
---driver                    Platform where the repository is hosted. If not
-                            specified, it will be inferred from the
-                            environment [string] [choices: "github", "gitlab"]
---repo                      Repository to be used for registering the runner.
-                            If not specified, it will be inferred from the
-                            environment                               [string]
---token                     Personal access token to register a self-hosted
-                            runner on the repository. If not specified, it
-                            will be inferred from the environment     [string]
 --cloud                     Cloud to deploy the runner
                        [string] [choices: "aws", "azure", "gcp", "kubernetes"]
 --cloud-region              Region where the instance is deployed. Choices:

--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -1,5 +1,9 @@
 # Command Reference: `runner`
 
+```bash
+cml runner [options]
+```
+
 Starts a [runner](/doc/self-hosted-runners) (either via any supported cloud
 compute provider or locally on-premise).
 

--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -9,6 +9,8 @@ compute provider or locally on-premise).
 
 ## Options
 
+Any [generic option](/doc/ref) in addition to:
+
 ```
 --labels                    One or more user-defined labels for this runner
                             (delimited with commas)  [string] [default: "cml"]

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -14,6 +14,8 @@ comments to the new PR if desired.
 
 ## Options
 
+Any [generic option](/doc/ref) in addition to:
+
 ```
 --pr                      Post to an existing PR/MR associated with the
                           specified commit                           [boolean]

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -1,16 +1,30 @@
 # Command Reference: `send-comment`
 
-Post a markdown comment on a commit.
-
 ```bash
-cml send-comment ./report.md
+cml send-comment [options] <markdown report file>
 ```
+
+Post a markdown report as a comment on a commit or pull/merge request.
 
 ⓘ If there's an associated pull/merge request, consider adding the `--pr` and
 `--update` flags.
 
 ⓘ If `cml pr` was used earlier in the workflow, use `--commit-sha=HEAD` to post
 comments to the new PR if desired.
+
+## Options
+
+```
+--pr                      Post to an existing PR/MR associated with the
+                          specified commit                           [boolean]
+--commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
+                                                                      [string]
+--update                  Update the last CML comment (if any) instead of
+                          creating a new one                         [boolean]
+--rm-watermark            Avoid watermark. CML needs a watermark to be able to
+                          distinguish CML reports from other comments in order
+                          to provide extra functionality.            [boolean]
+```
 
 ## FAQs and Known Issues
 

--- a/content/docs/ref/send-github-check.md
+++ b/content/docs/ref/send-github-check.md
@@ -1,8 +1,20 @@
 # Command Reference: `send-github-check`
 
+```bash
+cml send-github-check [options] <markdown report file>
+```
+
 Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
 [checks interface](https://docs.github.com/en/rest/reference/checks).
 
-```bash
-cml send-github-check ./report.md
+## Options
+
+```
+--commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
+                                                                      [string]
+--conclusion              Sets the conclusion status of the check.
+   [string] [choices: "success", "failure", "neutral", "cancelled", "skipped",
+                                             "timed_out"] [default: "success"]
+--title                   Sets title of the check.
+                                              [string] [default: "CML Report"]
 ```

--- a/content/docs/ref/send-github-check.md
+++ b/content/docs/ref/send-github-check.md
@@ -9,6 +9,8 @@ Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
 
 ## Options
 
+Any [generic option](/doc/ref) in addition to:
+
 ```
 --commit-sha, --head-sha  Commit SHA linked to this comment. Defaults to HEAD.
                                                                       [string]

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -1,6 +1,31 @@
 # Command Reference: `tensorboard-dev`
 
+```bash
+cml tensorboard-dev [options]
+```
+
 Return a link to a <https://tensorboard.dev> page.
+
+## Options
+
+```
+-c, --credentials   TB credentials as json. Usually found at
+                    ~/.config/tensorboard/credentials/uploader-creds.json. If
+                    not specified will look for the json at the env variable
+                    TB_CREDENTIALS.                        [string] [required]
+    --logdir        Directory containing the logs to process.         [string]
+    --name          Tensorboard experiment title. Max 100 characters. [string]
+    --description   Tensorboard experiment description. Markdown format. Max
+                    600 characters.                                   [string]
+    --md            Output as markdown [title || name](url).         [boolean]
+-t, --title         Markdown title, if not specified, param name will be used.
+                                                                      [string]
+-f, --file          Append the output to the given file. Create it if does not
+                    exist.                                            [string]
+    --rm-watermark  Avoid CML watermark.                             [boolean]
+```
+
+## Examples
 
 ```bash
 cml tensorboard-dev --logdir=./logs --title=Training --md >> report.md

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -8,6 +8,8 @@ Return a link to a <https://tensorboard.dev> page.
 
 ## Options
 
+Any [generic option](/doc/ref) in addition to:
+
 ```
 -c, --credentials   TB credentials as json. Usually found at
                     ~/.config/tensorboard/credentials/uploader-creds.json. If

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -32,7 +32,7 @@
   {
     "label": "Command Reference",
     "slug": "ref",
-    "source": false,
+    "source": "ref/index.md",
     "children": [
       {
         "label": "pr",


### PR DESCRIPTION
- add generic options index page
  + make into proper list with crosslinks/refs
- add all `cml --help` output for all commands (basic start, to replace with proper descriptions/examples in follow-up iterations)

---

- fixes https://github.com/iterative/cml/issues/361
- fixes #143
- fixes #109