### PR TITLE
Update YAML indentation for workflow example

### DIFF
--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -30,9 +30,9 @@ supported CI systems.
          steps:
             - uses: actions/checkout@v2
             - name: Train model
-               env:
+              env:
                   REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-               run: |
+              run: |
                   pip install -r requirements.txt
                   python train.py
 


### PR DESCRIPTION
When I copied the example as it was, I got a YAML validation error. Using http://www.yamllint.com/ showed that the cause was on lines 10 and 12, where `env:` and `run:` were right aligned with the `:` of `name`. Left aligning these lines fixed the issue for me.
