### PR TITLE
Change name of PNG to be saved

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -78,7 +78,7 @@ jobs:
 
           # Create CML report
           cat metrics.txt >> report.md
-          cml publish plot.png --md >> report.md
+          cml publish confusion_matrix.png --md >> report.md
           cml send-comment report.md
 ```
 


### PR DESCRIPTION
The description refers to the [basic use case](/doc/usage), in which the output image is called `confusion_matrix.png` rather than `plot.png`. Assuming users build off the basic example, I think it'd help to be consistent.