### PR TITLE
Add margin-bottom to toggle component

### DIFF
--- a/src/components/pages/Documentation/Markdown/styles.module.css
+++ b/src/components/pages/Documentation/Markdown/styles.module.css
@@ -434,6 +434,7 @@ a.card {
 .toggle {
   display: flex;
   flex-wrap: wrap;
+  margin: 0 0 16px;
 
   input {
     height: 0;


### PR DESCRIPTION
> Got a styling issue @julieg18 . Maybe someone in the web team can update the margin of the tabs section so there is some white space before the next paragraph? Currently it's gray -- looks odd:

\- @jorgeorpinel in [dvc.org#3178](https://github.com/iterative/dvc.org/pull/3178)

Already merged pr for this in dvc.org! 