### PR TITLE
height as prop for toggle component on markdown

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -341,7 +341,7 @@ are required to deploy EC2 instances.
 
 Click below to see credentials needed for supported compute providers.
 
-<toggle>
+<toggle height="250px">
 <tab title="AWS">
 
 - `AWS_ACCESS_KEY_ID`

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -341,7 +341,7 @@ are required to deploy EC2 instances.
 
 Click below to see credentials needed for supported compute providers.
 
-<toggle height="250px">
+<toggle>
 <tab title="AWS">
 
 - `AWS_ACCESS_KEY_ID`

--- a/src/components/pages/Documentation/Markdown/index.tsx
+++ b/src/components/pages/Documentation/Markdown/index.tsx
@@ -148,8 +148,9 @@ const ToggleTab: React.FC<{
 }
 
 const Toggle: React.FC<{
+  height?: string
   children: Array<{ props: { title: string } } | string>
-}> = ({ children }) => {
+}> = ({ height, children }) => {
   const [toggleId, setToggleId] = useState('')
   const {
     addNewToggle = (): null => null,
@@ -196,16 +197,21 @@ const Toggle: React.FC<{
           }
           onChange={(): void => updateToggleInd(toggleId, i)}
         >
-          {tab}
+          <div
+            className={cn('tab', styles.tab)}
+            style={{
+              minHeight: height
+            }}
+          >
+            {tab}
+          </div>
         </ToggleTab>
       ))}
     </div>
   )
 }
 
-const Tab: React.FC = ({ children }) => (
-  <div className={cn('tab', styles.tab)}>{children}</div>
-)
+const Tab: React.FC = ({ children }) => <>{children}</>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const renderAst = new (rehypeReact as any)({

--- a/src/components/pages/Documentation/Markdown/index.tsx
+++ b/src/components/pages/Documentation/Markdown/index.tsx
@@ -211,8 +211,6 @@ const Toggle: React.FC<{
   )
 }
 
-const Tab: React.FC = ({ children }) => <>{children}</>
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const renderAst = new (rehypeReact as any)({
   createElement: React.createElement,
@@ -223,7 +221,7 @@ const renderAst = new (rehypeReact as any)({
     card: Card,
     cards: Cards,
     toggle: Toggle,
-    tab: Tab
+    tab: React.Fragment
   }
 }).Compiler
 


### PR DESCRIPTION
This will be a simple addition to the current toggle tab on markdown. 
We can set a height through a `height` prop on the `toggle` component' `<toggle height="300px">` which will set height for all the tabs.

I have also used the prop on the `doc/self-hosted-runners` last tab which you could see once this review app is deployed.
<img width="700" alt="Screen Shot 2022-02-02 at 14 49 45" src="https://user-images.githubusercontent.com/20840228/152124030-544b4008-2646-4b74-9031-bc4e6818d24a.png">
 
current deployment [doc/self-hosted-runners](https://cml-dev-toggle-tab-heig-fetgnj.herokuapp.com/doc/self-hosted-runners)
 
 - [x] Port to dvc.org to solve https://github.com/iterative/dvc.org/issues/3179