### PR TITLE
runner --cloud-region: GCP zones

### DIFF
--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -36,8 +36,8 @@ Any [generic option](/doc/ref) in addition to:
   *current price*].
 - `--cloud-region={us-west,us-east,eu-west,eu-north,...}`:
   [Region](https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#cloud-regions)
-  where the instance is deployed. Also accepts native cloud regions [default:
-  `us-west`].
+  where the instance is deployed. Also accepts native AWS/Azure region or GCP
+  zone [default: `us-west`].
 - `--cloud-permission-set=<...>`:
   [AWS instance profile](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile)
   or

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -164,9 +164,15 @@ The `cml runner` command supports many options (see the
 - `--cloud-spot-price=<...>`: Maximum spot instance USD bidding price.
 - `--cloud-region={us-west,us-east,eu-west,eu-north,...}`:
   [Region](https://registry.terraform.io/providers/iterative/iterative/latest/docs/resources/task#cloud-regions)
-  where the instance is deployed. Also accepts native cloud regions.
-- `--cloud-permission-set=<...>`: AWS instance profile or GCP instance service
-  account.
+  where the instance is deployed. Also accepts native AWS/Azure region or GCP
+  zone.
+- `--cloud-permission-set=<...>`:
+  [AWS instance profile](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile)
+  or
+  [GCP instance service account](https://cloud.google.com/compute/docs/access/service-accounts).
+
+☝️ **Tip!** Check out the full
+[`cml runner` command reference](/doc/ref/runner).
 
 ## Environment Variables
 


### PR DESCRIPTION
- mention GCP needs zones not regions
- sync self-hosted docs with cmd ref
- add some links