### PR TITLE
Stop page from crashing on invalid anchor links

### DIFF
--- a/src/components/atoms/Link/index.tsx
+++ b/src/components/atoms/Link/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from '@reach/router'
 import GatsbyLink from 'gatsby-link'
 import { getRedirect } from '../../../utils/shared/redirects'
 import { scrollIntoLayout, getScrollNode } from '../../../utils/front/scroll'
+import safeQuerySelector from '../../../utils/front/safeQuerySelector'
 
 export type ILinkProps = {
   children: React.ReactNode
@@ -69,7 +70,7 @@ const ResultLinkComponent: React.FC<ILinkProps> = ({
 
 const scrollToHash = (hash: string, scrollOptions = {}): void => {
   if (hash) {
-    scrollIntoLayout(document.querySelector(hash), {
+    scrollIntoLayout(safeQuerySelector(hash), {
       waitImages: true,
       ...scrollOptions
     })

--- a/src/components/organisms/Page/utils.ts
+++ b/src/components/organisms/Page/utils.ts
@@ -3,6 +3,7 @@ import { useLocation } from '@reach/router'
 
 import { handleFrontRedirect } from '../../../utils/shared/redirects'
 import { scrollIntoLayout, getScrollNode } from '../../../utils/front/scroll'
+import safeQuerySelector from '../../../utils/front/safeQuerySelector'
 
 import * as styles from './styles.module.css'
 
@@ -11,7 +12,7 @@ export const useAnchorNavigation = (): void => {
 
   useEffect(() => {
     if (location.hash) {
-      const node = document.querySelector(location.hash)
+      const node = safeQuerySelector(location.hash)
 
       if (node) {
         scrollIntoLayout(node, { waitImages: true })

--- a/src/utils/front/safeQuerySelector.ts
+++ b/src/utils/front/safeQuerySelector.ts
@@ -1,0 +1,10 @@
+const safeQuerySelector = (query: string): null | Element => {
+  try {
+    const el = document.querySelector(query)
+    return el
+  } catch (err) {
+    return null
+  }
+}
+
+export default safeQuerySelector


### PR DESCRIPTION
* Matching [dvc.org#3107](https://github.com/iterative/dvc.org/pull/3107), adds `safeQuerySelector` and uses it in our `Link` code.
