### PR TITLE
Bitbucket REPO_TOKEN update

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -314,7 +314,7 @@ Use either:
 
 - your username and a
   [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/)
-  with `Write` permission for Pull requests, Pipelines, and Runners, or
+  with `Write` permission for Pull requests, Pipelines and Runners, or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts
   are the same as normal user accounts, with the only difference being the
   intended use case: you limit the account to only access the repositories where

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -312,7 +312,8 @@ variable with a Base64 encoded username and password.
 
 Use either:
 
-- your username and a [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/),
+- your username and a 
+  [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/),
   or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts
   are the same as normal user accounts, with the only difference being the

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -314,7 +314,7 @@ Use either:
 
 - your username and a
   [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/)
-  with `Write` permission for Pull requests, Pipelines and Runners, or
+  with `Write` permission for Pull requests, Pipelines, and Runners, or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts
   are the same as normal user accounts, with the only difference being the
   intended use case: you limit the account to only access the repositories where

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -313,7 +313,8 @@ variable with a Base64 encoded username and password.
 Use either:
 
 - your username and a
-  [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/),
+  [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/)
+  with `Write` permission for Pull requests, Pipelines, and Runners,
   or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts
   are the same as normal user accounts, with the only difference being the

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -312,8 +312,7 @@ variable with a Base64 encoded username and password.
 
 Use either:
 
-- your user access credentials (consider using
-  [Bitbucket Cloud App Passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords),
+- your username and a [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/),
   or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts
   are the same as normal user accounts, with the only difference being the

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -314,8 +314,7 @@ Use either:
 
 - your username and a
   [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/)
-  with `Write` permission for Pull requests, Pipelines, and Runners,
-  or
+  with `Write` permission for Pull requests, Pipelines, and Runners, or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts
   are the same as normal user accounts, with the only difference being the
   intended use case: you limit the account to only access the repositories where

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -312,7 +312,7 @@ variable with a Base64 encoded username and password.
 
 Use either:
 
-- your username and a 
+- your username and a
   [Bitbucket Cloud App Password](https://bitbucket.org/account/settings/app-passwords/),
   or
 - create a designated "CI/CD" _bot account_ for CML authentication. Bot accounts


### PR DESCRIPTION
After spending time trying to implement OAuth in CML I realised that Bitbucket still supports Basic Auth using [app passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) 🤦‍♂️ 

- closes https://github.com/iterative/cml/issues/914

