### PR TITLE
Document cml pr --auto-merge

### DIFF
--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -41,8 +41,12 @@ date > output.txt
 cml pr --auto-merge output.txt
 ```
 
-The `--auto-merge` option enables [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) (GitHub) or 
-[merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html) (GitLab) so the pull/merge request gets automatically merged as soon as checks succeed.
+The `--auto-merge` option enables
+[auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
+(GitHub) or
+[merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
+(GitLab) to merge the pull/merge request as soon as checks
+succeed.
 
 ## Command internals
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -17,6 +17,8 @@ preventing an infinite chain of runs.
 
 Any [generic option](/doc/ref) in addition to:
 
+- `--auto-merge`: Mark the PR/MR for automatic merging after tests pass
+  (unsupported by Bitbucket).
 - `--md`: Produce output in markdown format (`[CML Pull/Merge Request](url)`
   instead of `url`).
 - `--remote=<name or URL>`: Git remote name or URL [default: `origin`].
@@ -32,27 +34,7 @@ Any [generic option](/doc/ref) in addition to:
 cml pr "."
 ```
 
-### Automatically merge GitHub pull requests
-
-```yaml
-on: pull_request
-jobs:
-  cml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: iterative/setup-cml@v1
-      - name: Generate data
-        run: echo "Hello World" > output.txt
-      - name: Create and merge PR
-        run: |
-          cml ci
-          gh pr merge --rebase $(cml pr "output.txt")
-        env:
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-### Command internals
+## Command internals
 
 ```bash
 cml pr "**/*.py" "**/*.json"

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -45,8 +45,7 @@ The `--auto-merge` option enables
 [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-(GitLab) to merge the pull/merge request as soon as checks
-succeed.
+(GitLab) to merge the pull/merge request as soon as checks succeed.
 
 ## Command internals
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -31,7 +31,14 @@ Any [generic option](/doc/ref) in addition to:
 ### Commit all files in current working directory
 
 ```bash
-cml pr "."
+cml pr .
+```
+
+### Automatically merge pull requests
+
+```bash
+date > output.txt
+cml pr --auto-merge output.txt
 ```
 
 ## Command internals

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -41,6 +41,9 @@ date > output.txt
 cml pr --auto-merge output.txt
 ```
 
+The `--auto-merge` option enables [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) (GitHub) or 
+[merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html) (GitLab) so the pull/merge request gets automatically merged as soon as checks succeed.
+
 ## Command internals
 
 ```bash


### PR DESCRIPTION
It feels like recommending `gh` would be still useful until we address https://github.com/iterative/cml/issues/907 🤔 