### PR TITLE
Document `cml pr` auto–merge fallback

### DIFF
--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -40,7 +40,7 @@ date > output.txt
 cml pr --auto-merge output.txt
 ```
 
-The `--auto-merge` option enables
+The `--merge`, `--rebase`, and `--squash` options enable
 [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -44,7 +44,7 @@ The `--auto-merge` option enables
 [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-(GitLab) to merge the pull request as soon as checks succeed. If this
+(GitLab) to merge the pull request as soon as checks succeed. If
 waiting for checks isn't supported, `cml pr` will try to merge the pull request immediately.
 
 ## Command internals

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -17,8 +17,7 @@ preventing an infinite chain of runs.
 
 Any [generic option](/doc/ref) in addition to:
 
-- `--auto-merge`: Mark the PR/MR for automatic merging after tests pass
-  (unsupported by Bitbucket).
+- `--auto-merge=<merge|rebase|squash>`: Try to merge the PR/MR after creation.
 - `--md`: Produce output in markdown format (`[CML Pull/Merge Request](url)`
   instead of `url`).
 - `--remote=<name or URL>`: Git remote name or URL [default: `origin`].
@@ -45,7 +44,8 @@ The `--auto-merge` option enables
 [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-(GitLab) to merge the pull/merge request as soon as checks succeed.
+(GitLab) to merge the pull/merge request as soon as checks succeed. If this
+feature can't be enabled, `cml pr` will try to merge the pull request directly.
 
 ## Command internals
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -17,7 +17,7 @@ preventing an infinite chain of runs.
 
 Any [generic option](/doc/ref) in addition to:
 
-- `--auto-merge=<merge|rebase|squash>`: Try to merge the PR/MR after creation.
+- `--merge` / `--rebase` / `--squash`: Try to merge, rebase-merge or squash-merge the pull request after creation.
 - `--md`: Produce output in markdown format (`[CML Pull/Merge Request](url)`
   instead of `url`).
 - `--remote=<name or URL>`: Git remote name or URL [default: `origin`].
@@ -44,7 +44,7 @@ The `--auto-merge` option enables
 [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-(GitLab) to merge the pull/merge request as soon as checks succeed. If this
+(GitLab) to merge the pull request as soon as checks succeed. If this
 feature can't be enabled, `cml pr` will try to merge the pull request directly.
 
 ## Command internals

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -17,7 +17,8 @@ preventing an infinite chain of runs.
 
 Any [generic option](/doc/ref) in addition to:
 
-- `--merge`, `--rebase`, or `--squash`: Try to merge, rebase, or squash-merge the created PR after CI tests pass.
+- `--merge`, `--rebase`, or `--squash`: Try to merge, rebase, or squash-merge
+  the created PR after CI tests pass.
 - `--md`: Produce output in markdown format (`[CML Pull/Merge Request](url)`
   instead of `url`).
 - `--remote=<name or URL>`: Git remote name or URL [default: `origin`].
@@ -44,8 +45,8 @@ The `--merge`, `--rebase`, and `--squash` options enable
 [auto–merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request)
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-(GitLab) to merge the pull request as soon as checks succeed. If
-waiting for checks isn't supported, `cml pr` will try to merge the pull request immediately.
+(GitLab) to merge the pull request as soon as checks succeed. If waiting for
+checks isn't supported, `cml pr` will try to merge the pull request immediately.
 
 ## Command internals
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -17,7 +17,7 @@ preventing an infinite chain of runs.
 
 Any [generic option](/doc/ref) in addition to:
 
-- `--merge` / `--rebase` / `--squash`: Try to merge, rebase-merge or squash-merge the pull request after creation.
+- `--merge`, `--rebase`, or `--squash`: Try to merge, rebase, or squash-merge the created PR after CI tests pass.
 - `--md`: Produce output in markdown format (`[CML Pull/Merge Request](url)`
   instead of `url`).
 - `--remote=<name or URL>`: Git remote name or URL [default: `origin`].
@@ -45,7 +45,7 @@ The `--auto-merge` option enables
 (GitHub) or
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
 (GitLab) to merge the pull request as soon as checks succeed. If this
-feature can't be enabled, `cml pr` will try to merge the pull request directly.
+waiting for checks isn't supported, `cml pr` will try to merge the pull request immediately.
 
 ## Command internals
 


### PR DESCRIPTION
Documentation stub for https://github.com/iterative/cml/pull/932; I expect reviewers (hello, reviewers) 😉 to make some substantial changes if I don't do them before they arrive.