### PR TITLE
misc minor updates

### DIFF
--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -18,13 +18,13 @@ jobs:
     container: docker://ghcr.io/iterative/cml:0-dvc2-base1
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Train model
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cml ci --unshallow
           pip install -r requirements.txt  # Install dependencies
           dvc pull data --run-cache        # Pull data & run-cache from S3
           dvc repro                        # Reproduce pipeline

--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -71,7 +71,7 @@ you experience any problems, please don't hesitate to ping us in our
   - Large PRs may be merged without squashing (but related commits should be
     squashed)
 - **New releases**
-  - `git checkout master && git pull && git checkout -b M.m.p && npm version M.m.p && git push --set-upstream origin HEAD && gh pr create`
+  - `git checkout master && git pull && git checkout -b M.m.p && npm version M.m.p && gh pr create`
   - Merge the resulting PR
   - `git checkout master && git pull && git tag -f vM.m.p && git push --tags` or
     comment `/tag vM.m.p SHA` in the PR


### PR DESCRIPTION
- dvc: use `cml ci --unshallow`
- contrib: shorten guide (follow-up to #220)