### PR TITLE
fix: copy to clipboard

### DIFF
--- a/src/gatsby-plugin-theme-ui/components.js
+++ b/src/gatsby-plugin-theme-ui/components.js
@@ -184,7 +184,7 @@ export const Code = ({ children, lang = 'yml', filename, repo, sx = {} }) => {
             e.preventDefault()
             const pre = codeBlockRef.current
             if (!pre || !navigator.clipboard) return
-            navigator.clipboard.writeText(pre.textContent || pre.innerText)
+            navigator.clipboard.writeText(pre.innerText || pre.textContent)
           }}
         >
           Copy


### PR DESCRIPTION
#225

Quick fix for the copy to the clipboard. 
It's working fine with Chrome and FF on my end. But, Safari still fails to copy a few new lines. 

