### PR TITLE
Using proxy for plausible

### DIFF
--- a/src/components/organisms/Page/DefaultSEO/index.tsx
+++ b/src/components/organisms/Page/DefaultSEO/index.tsx
@@ -155,7 +155,8 @@ const SEO: React.FC<ISEOProps> = ({
       <script
         defer
         data-domain="cml.dev"
-        src="https://plausible.io/js/plausible.js"
+        src="https://dvc.org/pl/js/script.js"
+        data-api="https://dvc.org/pl/api/event"
       ></script>
     </Helmet>
   )


### PR DESCRIPTION
Updated current plausible URLs with dvc.org plausible proxy URL
