### PR TITLE
Document `cml send-github-check` authentication

### DIFF
--- a/content/docs/ref/send-github-check.md
+++ b/content/docs/ref/send-github-check.md
@@ -7,6 +7,12 @@ cml send-github-check [options] <markdown report file>
 Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
 [checks interface](https://docs.github.com/en/rest/reference/checks).
 
+ⓘ Authentication must be done through an automatically generated
+[`GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
+or a
+[GitHub App token](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps).
+Personal access tokens can't be used to create checks.
+
 ## Options
 
 Any [generic option](/doc/ref) in addition to:


### PR DESCRIPTION
Closes https://github.com/iterative/cml/issues/941 or, rather, the only actionable part of the issue.