### PR TITLE
Document additional `cml pr` options

### DIFF
--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -63,11 +63,6 @@ The `--merge`, `--rebase`, and `--squash` options enable
 checks isn't supported, `cml pr` will try to merge the pull request immediately.
 
 
-### Custom options example
-
-```cli
-$ cml pr --title="Periodic Retaining" --body="$(cat ./report.md)" --branch="$(date +%Y-%M)" .
-```
 
 ## Command internals
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -35,7 +35,7 @@ Any [generic option](/doc/ref) in addition to:
 - `--user-email=<address>`: Git user email for commits [default:
   `olivaw@iterative.ai`].
 - `--user-name=<...>`: Git user name for commits [default: `Olivaw[bot]`].
-- `--branch`: Custom git branch [default is auto-generated].
+- `--branch`: Custom Git branch [default is auto-generated].
 - `--title`: Custom PR title [default is auto-generated].
 - `--body`: Custom PR description [default is auto-generated].
 - `--message`: Git commit message [default is auto-generated].

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -35,10 +35,10 @@ Any [generic option](/doc/ref) in addition to:
 - `--user-email=<address>`: Git user email for commits [default:
   `olivaw@iterative.ai`].
 - `--user-name=<...>`: Git user name for commits [default: `Olivaw[bot]`].
-- `--branch`: Custom Git branch [default is auto-generated].
-- `--title`: Custom PR title [default is auto-generated].
-- `--body`: Custom PR description [default is auto-generated].
-- `--message`: Git commit message [default is auto-generated].
+- `--branch`: Pull request branch name [default: auto-generated].
+- `--title`: Pull request title [default: auto-generated].
+- `--body`: Pull request description [default: auto-generated].
+- `--message`: Commit message [default: auto-generated].
 
 ## Examples
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -62,8 +62,6 @@ The `--merge`, `--rebase`, and `--squash` options enable
 (GitLab) to merge the pull request as soon as checks succeed. If waiting for
 checks isn't supported, `cml pr` will try to merge the pull request immediately.
 
-
-
 ## Command internals
 
 ```cli

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -35,6 +35,10 @@ Any [generic option](/doc/ref) in addition to:
 - `--user-email=<address>`: Git user email for commits [default:
   `olivaw@iterative.ai`].
 - `--user-name=<...>`: Git user name for commits [default: `Olivaw[bot]`].
+- `--branch`: Custom git branch [default is auto-generated].
+- `--title`: Custom PR title [default is auto-generated].
+- `--body`: Custom PR description [default is auto-generated].
+- `--message`: Git commit message [default is auto-generated].
 
 ## Examples
 
@@ -57,6 +61,13 @@ The `--merge`, `--rebase`, and `--squash` options enable
 [merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
 (GitLab) to merge the pull request as soon as checks succeed. If waiting for
 checks isn't supported, `cml pr` will try to merge the pull request immediately.
+
+
+### Custom options example
+
+```cli
+$ cml pr --title="Periodic Retaining" --body="$(cat ./report.md)" --branch="$(date +%Y-%M)" .
+```
 
 ## Command internals
 


### PR DESCRIPTION
- [x] depends on https://github.com/iterative/cml/pull/1063
  + closes https://github.com/iterative/cml/issues/1017
- [x] depends on CML release after the above