### PR TITLE
Provision same instance on Bitbucket as on GH/GL

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -129,7 +129,7 @@ pipelines:
             cml runner \
                 --cloud=aws \
                 --cloud-region=us-west \
-                --cloud-type=m5.2xlarge \
+                --cloud-type=p2.xlarge \
                 --cloud-spot \
                 --labels=cml
     - step:


### PR DESCRIPTION
The explanation below the platform-specific details explicitly mentions that it'll provision a `p2.xlarge` instance.