### PR TITLE
Change how Bitbucket auth variables are shown

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -367,7 +367,7 @@ In either case, the steps to create a `REPO_TOKEN` are:
 
 1. Use a Base64 encoder of your choice to encode a Bitbucket username and
    password:
-   - `echo -n $USERNAME:$PASSWORD | base64`. The `-n` ensures the base64 does
+   - `echo -n {Bitbucket username}:{app password} | base64`. The `-n` ensures the base64 does
      not contain the trailing newline that `echo` adds by default.
    - copy the resulting Base64 token
 2. In your repository, go to **Repository Settings** &rightarrow; **Repository


### PR DESCRIPTION
While following the getting started docs for CML on Bitbucket, I ran into an issue because I generated the `REPO_TOKEN` incorrectly. I made a mistake while following `echo -n $USERNAME:$PASSWORD | base64`; left in the first `$`.

`$USERNAME` and `$PASSWORD` are not necessarily variables that are set when the user runs this command. Worst case, the local `$USERNAME` is different from the Bitbucket username.

I am not sure if my proposed solution is the ideal one, but earlier in this page we use `{}` to denote that the user should specify a variable here. Maybe we could use that approach here too.
