### PR TITLE
Automatically detect default branch with link check

### DIFF
--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -3,6 +3,4 @@ on:
   deployment_status:
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@v0.13.0
-    with:
-      main: master
+    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@auto-detect-diff-branch-in-action


### PR DESCRIPTION
This PR is both a testbed and likely a merged usage of `link-check` with a new QoL feature: automatically detecting the main branch. After going back into the context object, I found that we get the default branch handed to us even in `deployment_status`.

While testing it'll be pointed at `auto-detect-diff-branch-in-action`, but once the feature is shipped from the main link-check repo I'll update the PR to just bump the version.