### PR TITLE
Render `--cloud-startup-script` as inline code

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -482,7 +482,7 @@ workflow's YAML.
 Additionally, try to capture and include logs from the instance:
 
 For easy local access and debugging on the `cml runner` instance
-[check our example on using the --cloud-startup-script option](/doc/ref/runner#using---cloud-startup-script).
+[check our example on using the `--cloud-startup-script` option](/doc/ref/runner#using---cloud-startup-script).
 
 Then you can run the following:
 


### PR DESCRIPTION
I've added backticks around `--cloud-startup-script` for better readability. The linked section renders this flag as inline code as well.