### PR TITLE
Fix spelling of "Markdown"

### DIFF
--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -28,7 +28,7 @@ Any [generic option](/doc/ref) in addition to:
 
 - `--merge`, `--rebase`, or `--squash`: Try to merge, rebase, or squash-merge
   the created PR after CI tests pass.
-- `--md`: Produce output in markdown format (`[CML Pull/Merge Request](url)`
+- `--md`: Produce output in Markdown format (`[CML Pull/Merge Request](url)`
   instead of `url`).
 - `--skip-ci`: Prevent the PR/MR from triggering another CI run post-merge.
 - `--remote=<name or URL>`: Git remote name or URL [default: `origin`].

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -10,8 +10,8 @@ Publicly host an image for displaying in a CML report.
 
 Any [generic option](/doc/ref) in addition to:
 
-- `--md`: Produce output in markdown format.
-- `-t=<...>`, `--title=<...>`: Title for markdown output.
+- `--md`: Produce output in Markdown format.
+- `-t=<...>`, `--title=<...>`: Title for Markdown output.
 - `--mime-type=<...>`: Content
   [MIME type](https://www.iana.org/assignments/media-types/media-types.xhtml)
   [default: *inferred from content*].
@@ -22,7 +22,7 @@ Any [generic option](/doc/ref) in addition to:
 
 ## Examples
 
-To render an image in a markdown file:
+To render an image in a Markdown file:
 
 ```cli
 $ cml publish ./plot.png --md >> report.md

--- a/content/docs/ref/send-comment.md
+++ b/content/docs/ref/send-comment.md
@@ -4,7 +4,7 @@
 cml send-comment [options] <markdown report file>
 ```
 
-Post a markdown report as a comment on a commit or pull/merge request.
+Post a Markdown report as a comment on a commit or pull/merge request.
 
 <admon type="tip">
 

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -15,10 +15,10 @@ Any [generic option](/doc/ref) in addition to:
   *inferred from environment `TB_CREDENTIALS`*].
 - `--logdir=<path>`: Directory containing the logs to process.
 - `--name=<...>`: TensorBoard experiment title (up to 100 characters).
-- `--description=<...>`: TensorBoard experiment description (markdown format, up
+- `--description=<...>`: TensorBoard experiment description (Markdown format, up
   to 600 characters).
-- `--md`: Produce output in markdown format (`[title](url)`).
-- `-t=<...>`, `--title=<...>`: Title for markdown output [default: *value of
+- `--md`: Produce output in Markdown format (`[title](url)`).
+- `-t=<...>`, `--title=<...>`: Title for Markdown output [default: *value of
   `--name`*].
 - `--rm-watermark`: Don't inject a watermark into the comment. Will break some
   CML functionality which needs to distinguish CML reports from other comments.

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -151,7 +151,7 @@ CML provides a number of commands to help package the outputs of ML workflows
 report.
 
 Below is a list of CML commands for starting cloud compute runners, writing and
-publishing markdown reports to your CI/CD system.
+publishing Markdown reports to your CI/CD system.
 
 ∞ **[`runner`](/doc/ref/runner)**\
 Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners))\
@@ -166,11 +166,11 @@ Commit specified files to a new branch and create a pull request\
 e.g. `cml pr "**/*.json" "**/*.py" --md >> report.md`
 
 ∞ **[`send-comment`](/doc/ref/send-comment)**\
-Post a markdown report as a commit comment\
+Post a Markdown report as a commit comment\
 e.g. `cml send-comment report.md`
 
 ∞ **[`send-github-check`](/doc/ref/send-github-check)**\
-Post a markdown report as a GitHub check\
+Post a Markdown report as a GitHub check\
 e.g. `cml send-github-check report.md`
 
 ∞ **[`tensorboard-dev`](/doc/ref/tensorboard-dev)**\
@@ -180,7 +180,7 @@ e.g. `cml tensorboard-dev --logdir=./logs --md >> report.md`
 ### CML Reports
 
 The `cml send-comment` command can be used to post reports. CML reports are
-written in markdown ([GitHub](https://github.github.com/gfm),
+written in Markdown ([GitHub](https://github.github.com/gfm),
 [GitLab](https://docs.gitlab.com/ee/user/markdown.html), or
 [Bitbucket](https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html)
 flavors). That means they can contain images, tables, formatted text, HTML


### PR DESCRIPTION
I've fixed a spelling error: markdown -> **M**arkdown

See, e.g., https://www.markdownguide.org/ for a reference of spelling Markdown with a capital M.