### PR TITLE
Add missing preposition "to"

### DIFF
--- a/content/docs/contributing/core.md
+++ b/content/docs/contributing/core.md
@@ -13,8 +13,8 @@ Spotted a bug? Let us know!
 - For problems with [CML][cml-repo], search the
   [issue tracker](https://github.com/iterative/cml/issues) before creating a new
   issue (bug or feature request).
-- If you'd like implement/fix things yourself, please see below for help on how
-  to submit your changes.
+- If you'd like to implement/fix things yourself, please see below for help on
+  how to submit your changes.
 
 [issue tracker]: https://github.com/iterative/cml/issues
 


### PR DESCRIPTION
I've added a missing preposition "to". The change spans two lines because of line wrap.