### PR TITLE
Exclude sidebar example and plausible API endpoint from link check

### DIFF
--- a/config/link-check/excluded-files.yml
+++ b/config/link-check/excluded-files.yml
@@ -2,3 +2,4 @@
 - '**/*.test.js'
 - 'src/server/**/*'
 - '.github/workflows/**/*'
+- 'src/utils/shared/sidebar.*'

--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -3,3 +3,4 @@
 - 'https://dvc.us10.list-manage.com/subscribe/post?u=a08bf93caae4063c4e6a351f6&amp;id=24c0ecc49a'
 - '**linkedin.com/company/**'
 - url
+- 'https://dvc.org/pl/api/event'


### PR DESCRIPTION
Two links have been causing the cml.dev whole-site link check to fail, both are actually broken links, but also not really content.

- A katacoda link from the examples was causing an issue, despite us removing all katacoda links from content
- `https://dvc.org/pl/api/event` is a partial link for our Plausible proxy, so it doesn't need to stand alone as a link

Because of this, the sidebar logic file is now ignored by link check along with the exact `https://dvc.org/pl/api/event` being ignored as a link.

