### PR TITLE
document new subcommands

### DIFF
--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -46,8 +46,8 @@ jobs:
             -x actual \
             -y predicted \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 > plot.png
-          cml publish --md plot.png >> report.md
+          vl2png vega.json -s 1.5 > plot-confusion.png
+          echo '![](./plot-confusion.png)' >> report.md
 
           # Publish regularization function diff
           echo "### Effects of regularization" >> report.md
@@ -55,10 +55,10 @@ jobs:
             --target estimators.csv \
             -x Regularization \
             --show-vega master > vega.json
-          vl2png vega.json -s 1.5 > plot.png
-          cml publish --md plot.png >> report.md
+          vl2png vega.json -s 1.5 > plot-diff.png
+          echo '![](./plot-diff.png)' >> report.md
 
-          cml comment create report.md
+          cml comment create --publish report.md
 ```
 
 See the [example repository](https://github.com/iterative/cml_dvc_case) for

--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -127,7 +127,7 @@ Networking cost and transfer time can also be reduced using an appropriate
 <tab title="AWS">
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --cloud=aws \
   --cloud-region=us-west \
   --cloud-type=m+t4 \
@@ -139,7 +139,7 @@ $ cml runner \
 <tab title="GCP">
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --cloud=gcp \
   --cloud-region=us-west \
   --cloud-type=m+t4 \

--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -58,7 +58,7 @@ jobs:
           vl2png vega.json -s 1.5 > plot.png
           cml publish --md plot.png >> report.md
 
-          cml send-comment report.md
+          cml comment create report.md
 ```
 
 See the [example repository](https://github.com/iterative/cml_dvc_case) for

--- a/content/docs/ref/check.md
+++ b/content/docs/ref/check.md
@@ -4,7 +4,7 @@
 cml check create [options] <markdown report file>
 ```
 
-Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's
+Similar to [`comment create`](/doc/ref/comment#create), but using GitHub's
 [checks interface](https://docs.github.com/en/rest/reference/checks).
 
 ## Options

--- a/content/docs/ref/check.md
+++ b/content/docs/ref/check.md
@@ -1,7 +1,7 @@
-# Command Reference: `send-github-check`
+# Command Reference: `check`
 
 ```usage
-cml send-github-check [options] <markdown report file>
+cml check create [options] <markdown report file>
 ```
 
 Similar to [`send-comment`](/doc/ref/send-comment), but using GitHub's

--- a/content/docs/ref/comment.md
+++ b/content/docs/ref/comment.md
@@ -39,6 +39,15 @@ Any [generic option](/doc/ref) in addition to:
   [Git revision](https://git-scm.com/docs/gitrevisions) linked to this comment
   [default: `HEAD`].
 - `--pr`: Post to an existing PR/MR associated with the specified commit.
+- `--watch`: Watch for changes and automatically update the comment (doesn't
+  exit, consider
+  [appending `&` to run in the background](<https://en.wikipedia.org/wiki/Job_control_(Unix)#Implementation>)).
+- `--publish`: Upload any local images found in the Markdown report.
+- `--publish-url=<url>`: Self-hosted image server URL [default:
+  `https://asset.cml.dev`], see
+  [minroud-s3](https://github.com/iterative/minroud-s3).
+- `--native`: Uses `--driver`'s native capabilities to `--publish` assets
+  instead of `--publish-url` (not available on `--driver=github`).
 
 ## FAQs and Known Issues
 

--- a/content/docs/ref/comment.md
+++ b/content/docs/ref/comment.md
@@ -14,7 +14,7 @@ Update the last CML comment instead of creating a new one. If no previous
 comment is found, create a new one.
 
 ```usage
-cml comment create [options] <markdown report file>
+cml comment update [options] <markdown report file>
 ```
 
 <admon type="tip">

--- a/content/docs/ref/comment.md
+++ b/content/docs/ref/comment.md
@@ -39,9 +39,6 @@ Any [generic option](/doc/ref) in addition to:
   [Git revision](https://git-scm.com/docs/gitrevisions) linked to this comment
   [default: `HEAD`].
 - `--pr`: Post to an existing PR/MR associated with the specified commit.
-- `--rm-watermark`: Don't inject a watermark into the comment. Will break some
-  CML functionality (such as `--update`) which needs to distinguish CML reports
-  from other comments.
 
 ## FAQs and Known Issues
 

--- a/content/docs/ref/comment.md
+++ b/content/docs/ref/comment.md
@@ -1,22 +1,33 @@
-# Command Reference: `send-comment`
+# Command Reference: `comment`
 
-```usage
-cml send-comment [options] <markdown report file>
-```
+## create
 
 Post a Markdown report as a comment on a commit or pull/merge request.
 
+```usage
+cml comment create [options] <markdown report file>
+```
+
+## update
+
+Update the last CML comment instead of creating a new one. If no previous
+comment is found, create a new one.
+
+```usage
+cml comment create [options] <markdown report file>
+```
+
 <admon type="tip">
 
-If there's an associated pull/merge request, consider adding the `--pr` and
-`--update` flags.
+If there's an associated pull/merge request, consider using `update` with the
+`--pr` flag.
 
 </admon>
 
 <admon type="tip">
 
-If `cml pr` was used earlier in the workflow, use `--commit-sha=HEAD` to post
-comments to the new PR if desired.
+If [`cml pr`](/doc/ref/pr) was used earlier in the workflow, use
+`--commit-sha=HEAD` to post comments to the new PR if desired.
 
 </admon>
 
@@ -28,8 +39,6 @@ Any [generic option](/doc/ref) in addition to:
   [Git revision](https://git-scm.com/docs/gitrevisions) linked to this comment
   [default: `HEAD`].
 - `--pr`: Post to an existing PR/MR associated with the specified commit.
-- `--update`: Update the last CML comment (if any) instead of creating a new
-  one.
 - `--rm-watermark`: Don't inject a watermark into the comment. Will break some
   CML functionality (such as `--update`) which needs to distinguish CML reports
   from other comments.
@@ -42,8 +51,8 @@ Any [generic option](/doc/ref) in addition to:
 
   This
   [error](https://github.community/t/comment-api-does-not-describe-commit-id-has-been-locked/159853/2)
-  is caused by using the default GitHub token with `cml send-comment --update`.
-  Use a
+  is caused by using the default GitHub token with
+  [`cml comment update`](#update). Use a
   [personal access token (PAT)](/doc/self-hosted-runners?tab=GitHub#personal-access-token)
   instead.
 

--- a/content/docs/ref/index.md
+++ b/content/docs/ref/index.md
@@ -4,13 +4,13 @@
 
 All CML commands support the following options:
 
-- `--repo=<repo or org>`: Repository (or Organization) to be used [default:
+- `--repo=<repo or org>`: Repository (or Organization) URL or slug [default:
   *inferred from environment*].
 - `--token=<PAT>`:
   [Personal/project access token](https://cml.dev/doc/self-hosted-runners#personal-access-token)
   to be used [default: *inferred from environment*].
-- `--log={error,warn,info,debug}`: Maximum log level [default: `info`].
-- `--driver={github,gitlab,bitbucket}`: CI provider where the repository is
-  hosted [default: *inferred from environment*].
+- `--log={error,warn,info,debug}`: Logging verbosity [default: `info`].
+- `--driver={github,gitlab,bitbucket}`: CI provider where workflows are run
+  [default: *inferred from environment*].
 - `--help`: Show help.
 - `--version`: Show version number.

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -5,7 +5,8 @@ cml pr [options] <pathspec>...
 ```
 
 Commit specified files to a new branch and create a pull request. If sending a
-report afterwards, consider using `cml send-comment --pr --update`.
+report afterwards, consider using
+[`cml comment update --pr`](/doc/ref/comment#update).
 
 <admon type="info">
 

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -1,7 +1,7 @@
 # Command Reference: `pr`
 
 ```usage
-cml pr [options] <pathspec>...
+cml pr create [options] <pathspec>...
 ```
 
 Commit specified files to a new branch and create a pull request. If sending a
@@ -46,14 +46,14 @@ Any [generic option](/doc/ref) in addition to:
 ### Commit all files in current working directory
 
 ```cli
-$ cml pr .
+$ cml pr create .
 ```
 
 ### Automatically merge pull requests
 
 ```cli
 $ date > output.txt
-$ cml pr --auto-merge output.txt
+$ cml pr create --auto-merge output.txt
 ```
 
 The `--merge`, `--rebase`, and `--squash` options enable
@@ -66,7 +66,7 @@ checks isn't supported, `cml pr` will try to merge the pull request immediately.
 ## Command internals
 
 ```cli
-$ cml pr "**/*.py" "**/*.json"
+$ cml pr create "**/*.py" "**/*.json"
 ```
 
 is roughly equivalent to:

--- a/content/docs/ref/pr.md
+++ b/content/docs/ref/pr.md
@@ -53,7 +53,7 @@ $ cml pr create .
 
 ```cli
 $ date > output.txt
-$ cml pr create --auto-merge output.txt
+$ cml pr create --merge output.txt  # or --squash/--rebase
 ```
 
 The `--merge`, `--rebase`, and `--squash` options enable

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -4,7 +4,8 @@
 cml publish [options] <image file>
 ```
 
-Publicly host an image for displaying in a CML report.
+Publicly host an image for displaying in a CML report. Used internally by
+[`cml comment {create,update} --publish`](/doc/ref/comment).
 
 ## Options
 

--- a/content/docs/ref/publish.md
+++ b/content/docs/ref/publish.md
@@ -17,8 +17,6 @@ Any [generic option](/doc/ref) in addition to:
   [default: *inferred from content*].
 - `--native`: Uses CI provider's native storage instead of CML's.
   [Not available on GitHub](https://github.com/iterative/cml/wiki/Backend-Supported-Features).
-- `--rm-watermark`: Don't inject a watermark into the comment. Will break some
-  CML functionality which needs to distinguish CML reports from other comments.
 - `--url=<...>`: Use a custom storage URL instead of asset.cml.dev. See
   [`minroud-s3`](https://github.com/iterative/minroud-s3) for a reference
   implementation.

--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -1,7 +1,7 @@
 # Command Reference: `runner`
 
 ```usage
-cml runner [options]
+cml runner launch [options]
 ```
 
 Starts a [runner](/doc/self-hosted-runners) (either via any supported cloud
@@ -99,7 +99,7 @@ An AWS ARN to an instance-profile:
 - `arn:aws:iam::1234567890:instance-profile/dvc-s3-access`
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --cloud-permission-set=arn:aws:iam::1234567890:instance-profile/dvc-s3-access \
   ...
 ```
@@ -114,7 +114,7 @@ A GCP service account email &
 - `my-sa@myproject.iam.gserviceaccount.com,scopes=storage-rw`
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --cloud-permission-set=my-sa@myproject.iam.gserviceaccount.com,scopes=storage-rw,datastore \
   ...
 ```
@@ -297,7 +297,7 @@ instance and exiting with an error.
 For example:
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --cloud-startup-script=IyEvYmluL2Jhc2gKCmVjaG8gImhlbGxvIHdvcmxkIgo= \
   ...
 ```
@@ -314,7 +314,7 @@ This can be used for debugging, for example allowing SSH access for a GitHub
 user:
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --cloud-startup-script=$(echo 'echo "$(curl https://github.com/${{ github.actor }}.keys)" >> /home/ubuntu/.ssh/authorized_keys' | base64 -w 0) \
   ...
 ```
@@ -358,7 +358,7 @@ Azure.
    `cml runner` command:
 
    ```cli
-   $ cml runner --cloud=... --cloud-ssh-private="$(cat key.pem)"
+   $ cml runner launch --cloud=... --cloud-ssh-private="$(cat key.pem)"
    ```
 
 3. Access the instance from your local system by using the generated key as an

--- a/content/docs/ref/tensorboard-dev.md
+++ b/content/docs/ref/tensorboard-dev.md
@@ -20,8 +20,6 @@ Any [generic option](/doc/ref) in addition to:
 - `--md`: Produce output in Markdown format (`[title](url)`).
 - `-t=<...>`, `--title=<...>`: Title for Markdown output [default: *value of
   `--name`*].
-- `--rm-watermark`: Don't inject a watermark into the comment. Will break some
-  CML functionality which needs to distinguish CML reports from other comments.
 
 ## Examples
 

--- a/content/docs/ref/tensorboard.md
+++ b/content/docs/ref/tensorboard.md
@@ -1,7 +1,7 @@
-# Command Reference: `tensorboard-dev`
+# Command Reference: `tensorboard`
 
 ```usage
-cml tensorboard-dev [options]
+cml tensorboard connect [options]
 ```
 
 Return a link to a <https://tensorboard.dev> page.
@@ -24,5 +24,5 @@ Any [generic option](/doc/ref) in addition to:
 ## Examples
 
 ```cli
-$ cml tensorboard-dev --logdir=./logs --title=Training --md >> report.md
+$ cml tensorboard connect --logdir=./logs --title=Training --md >> report.md
 ```

--- a/content/docs/ref/workflow.md
+++ b/content/docs/ref/workflow.md
@@ -1,0 +1,19 @@
+# Command Reference: `workflow`
+
+```usage
+cml workflow rerun [options]
+```
+
+Rerun a workflow given a Job/Workflow ID.
+
+## Options
+
+Any [generic option](/doc/ref) in addition to:
+
+- `--id`: Job/Workflow ID.
+
+## Examples
+
+```cli
+$ cml workflow rerun --id=133742
+```

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -84,8 +84,8 @@ jobs:
 
           # Create CML report
           cat metrics.txt >> report.md
-          cml publish plot.png --md --title="Confusion Matrix" >> report.md
-          cml comment create report.md
+          echo '![](./plot.png "Confusion Matrix")' >> report.md
+          cml comment create --publish report.md
 ```
 
 </tab>
@@ -112,8 +112,8 @@ train-model:
     - python train.py
     # Create CML report
     - cat metrics.txt >> report.md
-    - cml publish plot.png --md --title="Confusion Matrix" >> report.md
-    - cml comment create report.md
+    - echo '![](./plot.png "Confusion Matrix")' >> report.md
+    - cml comment create --publish report.md
 ```
 
 </tab>
@@ -141,8 +141,8 @@ pipelines:
           - python train.py
           # Create CML report
           - cat metrics.txt >> report.md
-          - cml publish plot.png --md --title="Confusion Matrix" >> report.md
-          - cml comment create report.md
+          - echo '![](./plot.png "Confusion Matrix")' >> report.md
+          - cml comment create --publish report.md
 ```
 
 </tab>

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -85,7 +85,7 @@ jobs:
           # Create CML report
           cat metrics.txt >> report.md
           cml publish plot.png --md --title="Confusion Matrix" >> report.md
-          cml send-comment report.md
+          cml comment create report.md
 ```
 
 </tab>
@@ -113,7 +113,7 @@ train-model:
     # Create CML report
     - cat metrics.txt >> report.md
     - cml publish plot.png --md --title="Confusion Matrix" >> report.md
-    - cml send-comment report.md
+    - cml comment create report.md
 ```
 
 </tab>
@@ -142,7 +142,7 @@ pipelines:
           # Create CML report
           - cat metrics.txt >> report.md
           - cml publish plot.png --md --title="Confusion Matrix" >> report.md
-          - cml send-comment report.md
+          - cml comment create report.md
 ```
 
 </tab>
@@ -154,7 +154,7 @@ newly-launched instance. See [Environment Variables](#environment-variables)
 below for details on the `secrets` required.
 
 🎉 **Note that jobs can use any Docker container!** To use commands such as
-`cml send-comment` from a job, the only requirement is to
+`cml comment create` from a job, the only requirement is to
 [have CML installed](/doc/install).
 
 ## Docker Images
@@ -293,7 +293,7 @@ steps:
       REPO_TOKEN: ${{ steps.get-token.outputs.token }}
     run: |
       ...
-      cml send-comment report.md
+      cml comment create report.md
 ```
 
 Note that the Apps require the following **write**
@@ -302,7 +302,7 @@ Note that the Apps require the following **write**
 - Repository permissions (if used on a per-repo basis)
   - Administration (`cml runner`)
   - Checks (`cml check`)
-  - Pull requests (`cml {pr,send-comment}`)
+  - Pull requests (`cml {pr,comment}`)
 - Organization permissions (if used on an org)
   - Self-hosted runners (`cml runner`)
 

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -59,7 +59,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          cml runner \
+          cml runner launch \
               --cloud=aws \
               --cloud-region=us-west \
               --cloud-type=p2.xlarge \
@@ -96,7 +96,7 @@ deploy-runner:
   image: iterativeai/cml:0-dvc2-base1
   script:
     - |
-      cml runner \
+      cml runner launch \
           --cloud=aws \
           --cloud-region=us-west \
           --cloud-type=p2.xlarge \
@@ -126,7 +126,7 @@ pipelines:
         image: iterativeai/cml:0-dvc2-base1
         script:
           - |
-            cml runner \
+            cml runner launch \
                 --cloud=aws \
                 --cloud-region=us-west \
                 --cloud-type=m5.2xlarge \
@@ -441,7 +441,7 @@ on-premise GPU cluster, or any other cloud compute resource as a self-hosted
 runner. Simply [install CML](/doc/install) and then run:
 
 ```cli
-$ cml runner \
+$ cml runner launch \
   --repo="$REPOSITORY_URL" \
   --token="$PERSONAL_ACCESS_TOKEN" \
   --labels="local,runner" \

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -301,7 +301,7 @@ Note that the Apps require the following **write**
 
 - Repository permissions (if used on a per-repo basis)
   - Administration (`cml runner`)
-  - Checks (`cml send-github-check`)
+  - Checks (`cml check`)
   - Pull requests (`cml {pr,send-comment}`)
 - Organization permissions (if used on an org)
   - Self-hosted runners (`cml runner`)
@@ -332,7 +332,7 @@ For instance, to use a personal access token:
 
    ![](/img/personal_access_token.png)
 
-1. In your GitLab project, navigate to **Settings** &rightarrow; **CI/CD**
+2. In your GitLab project, navigate to **Settings** &rightarrow; **CI/CD**
    &rightarrow; **Variables** &rightarrow; **Add Variable**
 
    ![](/img/ci_cd_navigation.png)

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -63,8 +63,8 @@
         "slug": "check"
       },
       {
-        "label": "tensorboard-dev",
-        "slug": "tensorboard-dev"
+        "label": "tensorboard",
+        "slug": "tensorboard"
       }
     ]
   },

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -59,8 +59,8 @@
         "slug": "send-comment"
       },
       {
-        "label": "send-github-check",
-        "slug": "send-github-check"
+        "label": "check",
+        "slug": "check"
       },
       {
         "label": "tensorboard-dev",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -43,16 +43,12 @@
         "slug": "ci"
       },
       {
-        "label": "pr",
-        "slug": "pr"
-      },
-      {
-        "label": "publish",
-        "slug": "publish"
-      },
-      {
         "label": "runner",
         "slug": "runner"
+      },
+      {
+        "label": "pr",
+        "slug": "pr"
       },
       {
         "label": "comment",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -63,6 +63,10 @@
         "slug": "check"
       },
       {
+        "label": "workflow",
+        "slug": "workflow"
+      },
+      {
         "label": "tensorboard",
         "slug": "tensorboard"
       }

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -55,8 +55,8 @@
         "slug": "runner"
       },
       {
-        "label": "send-comment",
-        "slug": "send-comment"
+        "label": "comment",
+        "slug": "comment"
       },
       {
         "label": "check",

--- a/content/docs/start/bitbucket.md
+++ b/content/docs/start/bitbucket.md
@@ -13,8 +13,7 @@ all the supported CI systems.
    [these instructions](https://cml.dev/doc/self-hosted-runners?tab=Bitbucket#personal-access-token)
    to configure a Bitbucket token for CML.
 
-3. ⚠️ Follow
-   [these instructions](https://cml.dev/doc/ref/send-comment#bitbucket) to
+3. ⚠️ Follow [these instructions](https://cml.dev/doc/ref/comment#bitbucket) to
    enable the Pull Request Commit Links application.
 
 <admon type="tip">
@@ -44,7 +43,7 @@ $ git clone https://bitbucket.org/<your-username>/example-cml
 
              - cat metrics.txt >> report.md
              - cml publish plot.png --md >> report.md
-             - cml send-comment report.md
+             - cml comment create report.md
    ```
 
 5. In your text editor, open `train.py` and modify line 15 to `depth = 5`.
@@ -69,7 +68,8 @@ $ git clone https://bitbucket.org/<your-username>/example-cml
    </admon>
 
    Shortly, you should see a comment appear in the Pull Request with your CML
-   report. This is a result of the `cml send-comment` command in your workflow.
+   report. This is a result of the `cml comment create` command in your
+   workflow.
 
    ![](/img/bitbucket_cml_first_report.png)
 

--- a/content/docs/start/bitbucket.md
+++ b/content/docs/start/bitbucket.md
@@ -42,8 +42,8 @@ $ git clone https://bitbucket.org/<your-username>/example-cml
              - python train.py
 
              - cat metrics.txt >> report.md
-             - cml publish plot.png --md >> report.md
-             - cml comment create report.md
+             - echo '![](./plot.png)' >> report.md
+             - cml comment create --publish report.md
    ```
 
 5. In your text editor, open `train.py` and modify line 15 to `depth = 5`.

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -44,8 +44,8 @@ $ cd example_cml
              python train.py
 
              cat metrics.txt >> report.md
-             cml publish plot.png --md >> report.md
-             cml comment create report.md
+             echo '![](./plot.png)' >> report.md
+             cml comment create --publish report.md
    ```
 
 3. In your text editor, open `train.py` and modify line 15 to `depth = 5`.
@@ -160,6 +160,6 @@ steps:
       python train.py
 
       echo "# My first CML report" >> report.md
-      cml publish plot.png --md --title="Confusion Matrix" >> report.md
-      cml comment create report.md
+      echo '![](./plot.png "Confusion Matrix")' >> report.md
+      cml comment create --publish report.md
 ```

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -45,7 +45,7 @@ $ cd example_cml
 
              cat metrics.txt >> report.md
              cml publish plot.png --md >> report.md
-             cml send-comment report.md
+             cml comment create report.md
    ```
 
 3. In your text editor, open `train.py` and modify line 15 to `depth = 5`.
@@ -70,7 +70,8 @@ $ cd example_cml
    ![](/img/make_pr.png)
 
    Shortly, you should see a comment appear in the Pull Request with your CML
-   report. This is a result of the `cml send-comment` command in your workflow.
+   report. This is a result of the `cml comment create` command in your
+   workflow.
 
    ![](/img/cml_first_report.png)
 
@@ -100,8 +101,8 @@ Docker container.
 
 This action gives you:
 
-- Commands like `cml publish` and `cml send-comment` for publishing data
-  visualization and metrics from your CI workflow as comments in a pull request.
+- Commands like `cml comment create` for publishing data visualization and
+  metrics from your CI workflow as comments in a pull request.
 - `cml runner`, a command that enables workflows to provision cloud and
   on-premise computing resources for training models
 - The freedom 🦅 to mix and match CML with your favorite data science tools and
@@ -160,5 +161,5 @@ steps:
 
       echo "# My first CML report" >> report.md
       cml publish plot.png --md --title="Confusion Matrix" >> report.md
-      cml send-comment report.md
+      cml comment create report.md
 ```

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -40,7 +40,7 @@ $ cd example_cml
 
        - cat metrics.txt >> report.md
        - cml publish plot.png --md >> report.md
-       - cml send-comment report.md
+       - cml comment create report.md
    ```
 
 4. In your text editor, open `train.py` and modify line 15 to `depth = 5`.
@@ -72,7 +72,7 @@ $ cd example_cml
 
    Continue and submit the Merge Request. Shortly, you should see a comment
    appear in the Merge Request with your CML report. This is a result of the
-   `cml send-comment` command in your workflow.
+   `cml comment create` command in your workflow.
 
    ![](/img/cml_start_gitlab_end.png)
 

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -39,8 +39,8 @@ $ cd example_cml
        - python train.py
 
        - cat metrics.txt >> report.md
-       - cml publish plot.png --md >> report.md
-       - cml comment create report.md
+       - echo '![](./plot.png)' >> report.md
+       - cml comment create --publish report.md
    ```
 
 4. In your text editor, open `train.py` and modify line 15 to `depth = 5`.

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -155,7 +155,7 @@ publishing Markdown reports to your CI/CD system.
 
 ∞ **[`runner`](/doc/ref/runner)**\
 Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners))\
-e.g. `cml runner --cloud={aws,azure,gcp,kubernetes} ...`
+e.g. `cml runner launch --cloud={aws,azure,gcp,kubernetes} ...`
 
 ∞ **[`publish`](/doc/ref/publish)**\
 Publicly host an image for displaying in a CML report\

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -157,10 +157,6 @@ publishing Markdown reports to your CI/CD system.
 Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners))\
 e.g. `cml runner launch --cloud={aws,azure,gcp,kubernetes} ...`
 
-∞ **[`publish`](/doc/ref/publish)**\
-Publicly host an image for displaying in a CML report\
-e.g. `cml publish plot.png --md >> report.md`
-
 ∞ **[`pr`](/doc/ref/pr)**\
 Commit specified files to a new branch and create a pull request\
 e.g. `cml pr create "**/*.json" "**/*.py" --md >> report.md`

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -41,7 +41,7 @@ jobs:
         run: |
           # Post reports as comments in GitHub PRs
           cat results.txt >> report.md
-          cml send-comment report.md
+          cml comment create report.md
 ```
 
 The example above generates visual reports in pull requests:
@@ -79,7 +79,7 @@ create-CML-report:
   script:
     - cat metrics.txt >> report.md
     - cml publish plot.png --md >> report.md
-    - cml send-comment report.md
+    - cml comment create report.md
 ```
 
 ⚠️ You _must_ provide a
@@ -122,7 +122,7 @@ pipelines:
           - cat metrics.txt > report.md
           - echo >> report.md
           - cml publish plot.png --md >> report.md
-          - cml send-comment report.md
+          - cml comment create report.md
 ```
 
 ⚠️ You _must_ provide
@@ -165,9 +165,9 @@ e.g. `cml publish plot.png --md >> report.md`
 Commit specified files to a new branch and create a pull request\
 e.g. `cml pr "**/*.json" "**/*.py" --md >> report.md`
 
-∞ **[`send-comment`](/doc/ref/send-comment)**\
+∞ **[`comment`](/doc/ref/comment)**\
 Post a Markdown report as a commit comment\
-e.g. `cml send-comment report.md`
+e.g. `cml comment create report.md`
 
 ∞ **[`check`](/doc/ref/check)**\
 Post a Markdown report as a GitHub check\
@@ -179,7 +179,7 @@ e.g. `cml tensorboard-dev --logdir=./logs --md >> report.md`
 
 ### CML Reports
 
-The `cml send-comment` command can be used to post reports. CML reports are
+The `cml comment create` command can be used to post reports. CML reports are
 written in Markdown ([GitHub](https://github.github.com/gfm),
 [GitLab](https://docs.gitlab.com/ee/user/markdown.html), or
 [Bitbucket](https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html)

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -163,7 +163,7 @@ e.g. `cml publish plot.png --md >> report.md`
 
 ∞ **[`pr`](/doc/ref/pr)**\
 Commit specified files to a new branch and create a pull request\
-e.g. `cml pr "**/*.json" "**/*.py" --md >> report.md`
+e.g. `cml pr create "**/*.json" "**/*.py" --md >> report.md`
 
 ∞ **[`comment`](/doc/ref/comment)**\
 Post a Markdown report as a commit comment\

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -78,8 +78,8 @@ create-CML-report:
   image: iterativeai/cml:0-dvc2-base1
   script:
     - cat metrics.txt >> report.md
-    - cml publish plot.png --md >> report.md
-    - cml comment create report.md
+    - echo '![](./plot.png)' >> report.md
+    - cml comment create --publish report.md
 ```
 
 ⚠️ You _must_ provide a
@@ -121,8 +121,8 @@ pipelines:
         script:
           - cat metrics.txt > report.md
           - echo >> report.md
-          - cml publish plot.png --md >> report.md
-          - cml comment create report.md
+          - echo '![](./plot.png)' >> report.md
+          - cml comment create --publish report.md
 ```
 
 ⚠️ You _must_ provide
@@ -195,10 +195,11 @@ $ cat results.txt >> report.md
 ```
 
 🖼️ **Images** Display images using the markdown or HTML. Note that if an image
-is an output of your ML workflow (i.e., it is produced by your workflow), you
-will need to use the `cml publish` command to include it a CML report. For
-example, if `plot.png` is output by `python train.py`, run:
+is an output of your ML workflow (i.e. it is produced by your workflow), you
+will need to use the `--publish` option to include it a CML report. For example,
+if `plot.png` is output by `python train.py`, run:
 
 ```cli
-$ cml publish plot.png --md >> report.md
+$ echo '![](./plot.png)' >> report.md
+$ cml comment create --publish report.md
 ```

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -173,9 +173,9 @@ e.g. `cml comment create report.md`
 Post a Markdown report as a GitHub check\
 e.g. `cml check create report.md`
 
-∞ **[`tensorboard-dev`](/doc/ref/tensorboard-dev)**\
+∞ **[`tensorboard`](/doc/ref/tensorboard)**\
 Return a link to a <https://tensorboard.dev> page\
-e.g. `cml tensorboard-dev --logdir=./logs --md >> report.md`
+e.g. `cml tensorboard connect --logdir=./logs --md >> report.md`
 
 ### CML Reports
 

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -169,9 +169,9 @@ e.g. `cml pr "**/*.json" "**/*.py" --md >> report.md`
 Post a Markdown report as a commit comment\
 e.g. `cml send-comment report.md`
 
-∞ **[`send-github-check`](/doc/ref/send-github-check)**\
+∞ **[`check`](/doc/ref/check)**\
 Post a Markdown report as a GitHub check\
-e.g. `cml send-github-check report.md`
+e.g. `cml check create report.md`
 
 ∞ **[`tensorboard-dev`](/doc/ref/tensorboard-dev)**\
 Return a link to a <https://tensorboard.dev> page\

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -8,6 +8,7 @@
 
   "^/doc/ref/send-github-check(/.*)?$                                      /doc/ref/check$1 301",
   "^/doc/ref/send-comment(/.*)?$                                           /doc/ref/comment$1 301",
+  "^/doc/ref/tensorboard-dev(/.*)?$                                        /doc/ref/tensorboard$1 301",
 
   "^/doc/cml-with-npm(/.*)?$                                               /doc/install$1 301",
 

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -6,6 +6,8 @@
   "^/doc/start/start-github(/.*)?$                                         /doc/start/github",
   "^/doc/start/start-gitlab(/.*)?$                                         /doc/start/gitlab",
 
+  "^/doc/ref/send-github-check(/.*)?$                                      /doc/ref/check$1 301",
+
   "^/doc/cml-with-npm(/.*)?$                                               /doc/install$1 301",
 
   "^/(.+)/$                                                                /$1"

--- a/redirects-list.json
+++ b/redirects-list.json
@@ -7,6 +7,7 @@
   "^/doc/start/start-gitlab(/.*)?$                                         /doc/start/gitlab",
 
   "^/doc/ref/send-github-check(/.*)?$                                      /doc/ref/check$1 301",
+  "^/doc/ref/send-comment(/.*)?$                                           /doc/ref/comment$1 301",
 
   "^/doc/cml-with-npm(/.*)?$                                               /doc/install$1 301",
 

--- a/src/components/pages/Home/UseCasesSection/index.tsx
+++ b/src/components/pages/Home/UseCasesSection/index.tsx
@@ -87,8 +87,8 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div> </div>
                       <Tooltip type="reports">
                         <div>    <span>- cat metrics.txt &gt;&gt; report.md</span></div>
-                        <div>    <span>- cml publish plot.png --md &gt;&gt; report.md</span></div>
-                        <div>    <span>- cml comment create report.md</span></div>
+                        <div>    <span>- echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
+                        <div>    <span>- cml comment create --publish report.md</span></div>
                       </Tooltip>
                     </Code>
 
@@ -133,8 +133,8 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span> </span></div>
                       <Tooltip type="reports">
                         <div>          <span>cat metrics.txt &gt;&gt; report.md</span></div>
-                        <div>          <span>cml publish plot.png --md &gt;&gt; report.md</span></div>
-                        <div>          <span>cml comment create report.md</span></div>
+                        <div>          <span>echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
+                        <div>          <span>cml comment create --publish report.md</span></div>
                       </Tooltip>
                     </Code>
                     <ExampleBox title="CML Report">
@@ -180,8 +180,8 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>      <span>--target loss.csv --show-vega master &gt; vega.json</span></div>
                       <Tooltip type="reports">
                         <div>    <span>- vl2png vega.json &gt; plot.png</span></div>
-                        <div>    <span>- cml publish --md plot.png &gt;&gt; report.md</span></div>
-                        <div>    <span>- cml comment create report.md</span></div>
+                        <div>    <span>- echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
+                        <div>    <span>- cml comment create --publish report.md</span></div>
                       </Tooltip>
                     </Code>
                     <ExampleBox title="CML Report">
@@ -242,8 +242,8 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>            <span>--target loss.csv --show-vega master &gt; vega.json</span></div>
                       <Tooltip type="reports">
                         <div>          <span>vl2png vega.json -s 1.5 &gt; plot.png</span></div>
-                        <div>          <span>cml publish --md plot.png &gt;&gt; report.md</span></div>
-                        <div>          <span>cml comment create report.md </span></div>
+                        <div>          <span>echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
+                        <div>          <span>cml comment create --publish report.md</span></div>
                       </Tooltip>
                     </Code>
 
@@ -392,8 +392,8 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span> </span></div>
                       <div>    <span>- echo &quot;## Report from your EC2 Instance&quot; &gt; report.md</span></div>
                       <div>    <span>- cat metrics.txt &gt;&gt; report.md</span></div>
-                      <div>    <span>- cml publish &quot;plot.png&quot; --md &gt;&gt; report.md</span></div>
-                      <div>    <span>- cml comment create report.md</span></div>
+                      <div>    <span>- echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
+                      <div>    <span>- cml comment create --publish report.md</span></div>
                     </Code>
 
                     <ExampleBox title="CML Report">
@@ -455,8 +455,8 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span> </span></div>
                       <div>        <span>echo &quot;## Report from your EC2 Instance&quot; &gt; report.md</span></div>
                       <div>        <span>cat metrics.txt &gt;&gt; report.md</span></div>
-                      <div>        <span>cml publish &quot;plot.png&quot; --md &gt;&gt; report.md</span></div>
-                      <div>        <span>cml comment create report.md</span></div>
+                      <div>        <span>echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
+                      <div>        <span>cml comment create --publish report.md</span></div>
                     </Code>
 
                     <ExampleBox title="CML Report">
@@ -521,7 +521,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>    <span>- convert +append final_owl.png master_owl.png out.png</span></div>
                       <div>    <span>- convert out.png -resize 75% out_shrink.png</span></div>
                       <div>    <span>- echo &quot;### Workspace vs. Master&quot; &gt;&gt; report.md</span></div>
-                      <div>    <span>- cml publish out_shrink.png --md &gt;&gt; report.md</span></div>
+                      <div>    <span>- echo &#x27;![](./out_shrink.png)&#x27; &gt;&gt; report.md</span></div>
                       <div><span> </span></div>
                       <div>    <span># Report training parameters</span></div>
                       <div>    <span>- echo &quot;## Training parameter diffs&quot; &gt;&gt; report.md</span></div>
@@ -532,7 +532,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>    <span>- echo &quot;## GPU info&quot; &gt;&gt; report.md</span></div>
                       <div>    <span>- cat gpu_info.txt &gt;&gt; report.md</span></div>
                       <div><span> </span></div>
-                      <div>    <span>- cml comment create report.md </span></div>
+                      <div>    <span>- cml comment create --publish report.md</span></div>
                     </Code>
 
                     <ExampleBox title="CML Report">
@@ -611,7 +611,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>        <span>convert +append final_owl.png master_owl.png out.png</span></div>
                       <div>        <span>convert out.png -resize 75%  out_shrink.png</span></div>
                       <div>        <span>echo &quot;### Workspace vs. Main&quot; &gt;&gt; report.md</span></div>
-                      <div>        <span>cml publish out_shrink.png --md --title &apos;compare&apos; &gt;&gt; report.md</span></div>
+                      <div>        <span>echo &#x27;![](./out_shrink.png &quot;compare&quot;)&#x27; &gt;&gt; report.md</span></div>
                       <div><span> </span></div>
                       <div>        <span>echo &quot;## Training metrics&quot; &gt;&gt; report.md</span></div>
                       <div>        <span>dvc params diff master --show-md &gt;&gt; report.md</span></div>
@@ -620,7 +620,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>        <span>echo &quot;## GPU info&quot; &gt;&gt; report.md</span></div>
                       <div>        <span>cat gpu_info.txt &gt;&gt; report.md</span></div>
                       <div><span> </span></div>
-                      <div>        <span>cml comment create report.md </span></div>
+                      <div>        <span>cml comment create --publish report.md</span></div>
                     </Code>
                     <ExampleBox title="CML Report">
                       <a target="_blank" rel="noreferrer" href="https://github.com/iterative/cml_cloud_case/pull/11">

--- a/src/components/pages/Home/UseCasesSection/index.tsx
+++ b/src/components/pages/Home/UseCasesSection/index.tsx
@@ -370,7 +370,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>  <span>script:</span></div>
                       <Tooltip type="reports">
-                        <div>    <span>- cml runner</span></div>
+                        <div>    <span>- cml runner launch</span></div>
                         <div>      <span>--cloud aws</span></div>
                         <div>      <span>--cloud-region us-west</span></div>
                         <div>      <span>--cloud-type t2.micro</span></div>
@@ -426,7 +426,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>          <span>AWS_SECRET_ACCESS_KEY: {"${{ secrets.AWS_SECRET_ACCESS_KEY }}"}</span></div>
                       <div>        <span>run: |</span></div>
                       <Tooltip type="reports">
-                        <div>          <span>cml runner \</span></div>
+                        <div>          <span>cml runner launch \</span></div>
                         <div>          <span>--cloud aws \</span></div>
                         <div>          <span>--cloud-region us-west \</span></div>
                         <div>          <span>--cloud-type=t2.micro \</span></div>
@@ -488,7 +488,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>  <span>script:</span></div>
                       <Tooltip type="reports">
-                        <div>    <span>- cml runner \</span></div>
+                        <div>    <span>- cml runner launch \</span></div>
                         <div>      <span>--cloud aws \</span></div>
                         <div>      <span>--cloud-region us-west \</span></div>
                         <div>      <span>--cloud-type=p2.xlarge \</span></div>
@@ -566,7 +566,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>          <span>AWS_SECRET_ACCESS_KEY: {"${{ secrets.AWS_SECRET_ACCESS_KEY }}"} </span></div>
                       <div>        <span>run: |</span></div>
                       <Tooltip type="reports">
-                        <div>          <span>cml runner \</span></div>
+                        <div>          <span>cml runner launch \</span></div>
                         <div>          <span>--cloud aws \</span></div>
                         <div>          <span>--cloud-region us-west \</span></div>
                         <div>          <span>--cloud-type=p2.xlarge \</span></div>

--- a/src/components/pages/Home/UseCasesSection/index.tsx
+++ b/src/components/pages/Home/UseCasesSection/index.tsx
@@ -88,7 +88,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <Tooltip type="reports">
                         <div>    <span>- cat metrics.txt &gt;&gt; report.md</span></div>
                         <div>    <span>- cml publish plot.png --md &gt;&gt; report.md</span></div>
-                        <div>    <span>- cml send-comment report.md</span></div>
+                        <div>    <span>- cml comment create report.md</span></div>
                       </Tooltip>
                     </Code>
 
@@ -134,7 +134,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <Tooltip type="reports">
                         <div>          <span>cat metrics.txt &gt;&gt; report.md</span></div>
                         <div>          <span>cml publish plot.png --md &gt;&gt; report.md</span></div>
-                        <div>          <span>cml send-comment report.md</span></div>
+                        <div>          <span>cml comment create report.md</span></div>
                       </Tooltip>
                     </Code>
                     <ExampleBox title="CML Report">
@@ -181,7 +181,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <Tooltip type="reports">
                         <div>    <span>- vl2png vega.json &gt; plot.png</span></div>
                         <div>    <span>- cml publish --md plot.png &gt;&gt; report.md</span></div>
-                        <div>    <span>- cml send-comment report.md</span></div>
+                        <div>    <span>- cml comment create report.md</span></div>
                       </Tooltip>
                     </Code>
                     <ExampleBox title="CML Report">
@@ -243,7 +243,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <Tooltip type="reports">
                         <div>          <span>vl2png vega.json -s 1.5 &gt; plot.png</span></div>
                         <div>          <span>cml publish --md plot.png &gt;&gt; report.md</span></div>
-                        <div>          <span>cml send-comment report.md </span></div>
+                        <div>          <span>cml comment create report.md </span></div>
                       </Tooltip>
                     </Code>
 
@@ -280,7 +280,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                         <div>            <span>--md &gt;&gt; report.md</span></div>
                       </Tooltip>
                       <Tooltip type="reports">
-                        <div>        <span>- cml send-comment report.md</span></div>
+                        <div>        <span>- cml comment create report.md</span></div>
                       </Tooltip>
                       <div><span> </span></div>
                       <Tooltip type="dependencies">
@@ -334,7 +334,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                         <div>            <span>--md &gt;&gt; report.md</span></div>
                       </Tooltip>
                       <Tooltip type="reports">
-                        <div>          <span>cml send-comment report.md</span></div>
+                        <div>          <span>cml comment create report.md</span></div>
                       </Tooltip>
                       <div><span> </span></div>
                       <Tooltip type="dependencies">
@@ -393,7 +393,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>    <span>- echo &quot;## Report from your EC2 Instance&quot; &gt; report.md</span></div>
                       <div>    <span>- cat metrics.txt &gt;&gt; report.md</span></div>
                       <div>    <span>- cml publish &quot;plot.png&quot; --md &gt;&gt; report.md</span></div>
-                      <div>    <span>- cml send-comment report.md</span></div>
+                      <div>    <span>- cml comment create report.md</span></div>
                     </Code>
 
                     <ExampleBox title="CML Report">
@@ -456,7 +456,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>        <span>echo &quot;## Report from your EC2 Instance&quot; &gt; report.md</span></div>
                       <div>        <span>cat metrics.txt &gt;&gt; report.md</span></div>
                       <div>        <span>cml publish &quot;plot.png&quot; --md &gt;&gt; report.md</span></div>
-                      <div>        <span>cml send-comment report.md</span></div>
+                      <div>        <span>cml comment create report.md</span></div>
                     </Code>
 
                     <ExampleBox title="CML Report">
@@ -532,7 +532,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>    <span>- echo &quot;## GPU info&quot; &gt;&gt; report.md</span></div>
                       <div>    <span>- cat gpu_info.txt &gt;&gt; report.md</span></div>
                       <div><span> </span></div>
-                      <div>    <span>- cml send-comment report.md </span></div>
+                      <div>    <span>- cml comment create report.md </span></div>
                     </Code>
 
                     <ExampleBox title="CML Report">
@@ -620,7 +620,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>        <span>echo &quot;## GPU info&quot; &gt;&gt; report.md</span></div>
                       <div>        <span>cat gpu_info.txt &gt;&gt; report.md</span></div>
                       <div><span> </span></div>
-                      <div>        <span>cml send-comment report.md </span></div>
+                      <div>        <span>cml comment create report.md </span></div>
                     </Code>
                     <ExampleBox title="CML Report">
                       <a target="_blank" rel="noreferrer" href="https://github.com/iterative/cml_cloud_case/pull/11">

--- a/src/components/pages/Home/UseCasesSection/index.tsx
+++ b/src/components/pages/Home/UseCasesSection/index.tsx
@@ -274,7 +274,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>    <span>script:</span></div>
                       <div>        <span>- pip install -r requirements.txt</span></div>
                       <Tooltip type="tensorboard">
-                        <div>        <span>- cml tensorboard-dev \</span></div>
+                        <div>        <span>- cml tensorboard connect \</span></div>
                         <div>            <span>--logdir logs \</span></div>
                         <div>            <span>--name &quot;Go to tensorboard&quot; \</span></div>
                         <div>            <span>--md &gt;&gt; report.md</span></div>
@@ -328,7 +328,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>          <span>pip install -r requirements.txt</span></div>
                       <div><span> </span></div>
                       <Tooltip type="tensorboard">
-                        <div>          <span>cml tensorboard-dev \</span></div>
+                        <div>          <span>cml tensorboard connect \</span></div>
                         <div>            <span>--logdir logs \</span></div>
                         <div>            <span>--name &quot;Go to tensorboard&quot; \</span></div>
                         <div>            <span>--md &gt;&gt; report.md</span></div>


### PR DESCRIPTION
- fixes #316
  + top-level options
  + `send-github-check` => `check create`
  + `send-comment` => `comment {create,update}`
  + `pr` => `pr create`
  + `runner` => `runner launch`
  + `tensorboard-dev` => `tensorboard connect`
  + add `workflow` stub (fixes #188)
  + drop `--rm-watermark`
  + `publish` => `comment {create,update} --publish`
  + hide `publish`
  + add `comment {create,update} [--watch,--publish-url,--native]` (fixes #266, closes #317)