### PR TITLE
Fix redirects

### DIFF
--- a/src/@dvcorg/gatsby-theme-iterative/redirects.js
+++ b/src/@dvcorg/gatsby-theme-iterative/redirects.js
@@ -1,0 +1,1 @@
+module.exports = require('../../../redirects-list.json')


### PR DESCRIPTION
The current redirects on `cml.dev` show a 404 page first instead of getting redirected from the server. I guess it's because the redirects are not preloaded. I believe preloading them would fix that.

Fixes #346 

It's working fine now: https://cml-dev-fix-redirect-gnyinegbc.herokuapp.com/chat