### PR TITLE
Minor docs fixes

### DIFF
--- a/content/docs/start/bitbucket.md
+++ b/content/docs/start/bitbucket.md
@@ -1,8 +1,6 @@
 # Get Started with CML on Bitbucket
 
-Here, we'll walk through a tutorial to start using CML. For simplicity, we'll
-show the demo in Bitbucket Pipelines, but instructions are pretty similar for
-all the supported CI systems.
+Here, we'll walk through a tutorial to start using CML with Bitbucket Pipelines.
 
 1. Fork our
    [example project repository](https://bitbucket.org/iterative-ai/example-cml).
@@ -78,7 +76,7 @@ repository, the workflow in your `bitbucket-pipelines.yml` file gets run and a
 report generated.
 
 CML commands let you display relevant results from the workflow, like model
-performance metrics and vizualizations, in Bitbucket checks and comments. What
+performance metrics and visualizations, in Bitbucket checks and comments. What
 kind of workflow you want to run, and want to put in your CML report, is up to
 you.
 

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -2,8 +2,8 @@
 
 Here, we'll walk through a tutorial to start using CML with GitHub Actions.
 
-1. Fork our [example project
-   repository](https://github.com/iterative/example_cml).
+1. Fork our
+   [example project repository](https://github.com/iterative/example_cml).
 
    ![](/img/fork_cml_project.png)
 

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -1,11 +1,9 @@
 # Get Started with CML on GitHub
 
-Here, we'll walk through a tutorial to start using CML. For simplicity, we'll
-show the demo in GitHub Actions, but instructions are pretty similar for all the
-supported CI systems.
+Here, we'll walk through a tutorial to start using CML with GitHub Actions.
 
-1. Fork our
-   [example project repository](https://github.com/iterative/example_cml).
+1. Fork our [example project
+   repository](https://github.com/iterative/example_cml).
 
    ![](/img/fork_cml_project.png)
 
@@ -80,7 +78,7 @@ repository, the workflow in your `.github/workflows/cml.yaml` file gets run and
 a report generated.
 
 CML commands let you display relevant results from the workflow, like model
-performance metrics and vizualizations, in GitHub checks and comments. What kind
+performance metrics and visualizations, in GitHub checks and comments. What kind
 of workflow you want to run, and want to put in your CML report, is up to you.
 
 ## Final Solution

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -2,13 +2,13 @@
 
 Here, we'll walk through a tutorial to start using CML with GitLab CI/CD.
 
-1. Fork our [example project
-   repository](https://gitlab.com/iterative.ai/example_cml).
+1. Fork our
+   [example project repository](https://gitlab.com/iterative.ai/example_cml).
 
    ![](/img/gitlab_fork_cml_project.png)
 
-2. ⚠️ Follow [these
-   instructions](https://cml.dev/doc/self-hosted-runners?tab=GitLab#personal-access-token)
+2. ⚠️ Follow
+   [these instructions](https://cml.dev/doc/self-hosted-runners?tab=GitLab#personal-access-token)
    to configure a GitLab access token for CML.
 
 <admon type="tip">

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -1,16 +1,14 @@
 # Get Started with CML on GitLab
 
-Here, we'll walk through a tutorial to start using CML. For simplicity, we'll
-show the demo in GitLab CI/CD, but instructions are pretty similar for all the
-supported CI systems.
+Here, we'll walk through a tutorial to start using CML with GitLab CI/CD.
 
-1. Fork our
-   [example project repository](https://gitlab.com/iterative.ai/example_cml).
+1. Fork our [example project
+   repository](https://gitlab.com/iterative.ai/example_cml).
 
    ![](/img/gitlab_fork_cml_project.png)
 
-2. ⚠️ Follow
-   [these instructions](https://cml.dev/doc/self-hosted-runners?tab=GitLab#personal-access-token)
+2. ⚠️ Follow [these
+   instructions](https://cml.dev/doc/self-hosted-runners?tab=GitLab#personal-access-token)
    to configure a GitLab access token for CML.
 
 <admon type="tip">
@@ -81,7 +79,7 @@ repository, the workflow in your `.gitlab-ci.yml` file gets run and a report
 generated.
 
 CML commands let you display relevant results from the workflow, like model
-performance metrics and vizualizations, in GitLab comments. What kind of
+performance metrics and visualizations, in GitLab comments. What kind of
 workflow you want to run, and want to put in your CML report, is up to you.
 
 ## Final Solution

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -1,12 +1,12 @@
 # Using CML
 
-A GitLab, GitHub, or Bitbucket account is required. Familiarity with
-[GitHub Actions](https://help.github.com/en/actions) or
-[GitLab CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration)
-may also be beneficial.
+A GitLab, GitHub, or Bitbucket account is required. Familiarity with [GitHub
+Actions](https://help.github.com/en/actions), [GitLab
+CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration),
+or [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines) may
+also be beneficial.
 
-<toggle>
-<tab title="GitHub">
+<toggle> <tab title="GitHub">
 
 The key file in any CML project is `.github/workflows/cml.yaml`:
 
@@ -47,12 +47,11 @@ jobs:
 The example above generates visual reports in pull requests:
 [![](/img/cml_first_report.png)](https://github.com/iterative/cml_base_case/pull/2)
 
-We helpfully provide CML and other useful libraries pre-installed on our
-[custom Docker images](/doc/self-hosted-runners#docker-images). In the above
-example, uncommenting the
-`container: docker://ghcr.io/iterative/cml:0-dvc2-base1` field will make the
-runner pull the CML Docker image. The image already has Node.js, Python 3, DVC
-and CML set up on an Ubuntu LTS base for convenience.
+We helpfully provide CML and other useful libraries pre-installed on our [custom
+Docker images](/doc/self-hosted-runners#docker-images). In the above example,
+uncommenting the `container: docker://ghcr.io/iterative/cml:0-dvc2-base1` field
+will make the runner pull the CML Docker image. The image already has Node.js,
+Python 3, DVC and CML set up on an Ubuntu LTS base for convenience.
 
 ### Example projects
 
@@ -61,8 +60,7 @@ and CML set up on an Ubuntu LTS base for convenience.
 - [CML with Tensorboard](https://github.com/iterative/cml_tensorboard_case)
 - [CML with EC2 GPU](https://github.com/iterative/cml_cloud_case)
 
-</tab>
-<tab title="GitLab">
+</tab> <tab title="GitLab">
 
 The key file in any CML project is `.gitlab-ci.yml`:
 
@@ -82,18 +80,19 @@ create-CML-report:
     - cml comment create --publish report.md
 ```
 
-⚠️ You _must_ provide a
-[personal or project access token (PAT)](/doc/self-hosted-runners#personal-access-token)
-via a `REPO_TOKEN` variable.
+⚠️ You _must_ provide a [personal or project access token
+(PAT)](/doc/self-hosted-runners#personal-access-token) via a `REPO_TOKEN`
+variable.
 
 The example above generates visual reports in merge requests:
-[![](/img/GitLab_CML_report.png '=400')](https://gitlab.com/iterative.ai/cml-base-case/-/merge_requests/3)
+[![](/img/GitLab_CML_report.png
+'=400')](https://gitlab.com/iterative.ai/cml-base-case/-/merge_requests/3)
 
-We helpfully provide CML and other useful libraries pre-installed on our
-[custom Docker images](/doc/self-hosted-runners#docker-images). In the above
-example, the `image: iterativeai/cml:0-dvc2-base1` field will make the runner
-pull the CML Docker image. The image already has Node.js, Python 3, DVC and CML
-set up on an Ubuntu LTS base for convenience.
+We helpfully provide CML and other useful libraries pre-installed on our [custom
+Docker images](/doc/self-hosted-runners#docker-images). In the above example,
+the `image: iterativeai/cml:0-dvc2-base1` field will make the runner pull the
+CML Docker image. The image already has Node.js, Python 3, DVC and CML set up on
+an Ubuntu LTS base for convenience.
 
 ### Example projects
 
@@ -102,8 +101,7 @@ set up on an Ubuntu LTS base for convenience.
 - [CML with Tensorboard](https://gitlab.com/iterative.ai/cml-tensorboard-case)
 - [CML with EC2 GPU](https://gitlab.com/iterative.ai/cml-cloud-case)
 
-</tab>
-<tab title="Bitbucket">
+</tab> <tab title="Bitbucket">
 
 The key file in any CML project is `bitbucket-pipelines.yml`:
 
@@ -125,24 +123,24 @@ pipelines:
           - cml comment create --publish report.md
 ```
 
-⚠️ You _must_ provide
-[access credentials](/doc/self-hosted-runners#personal-access-token) via a
-`REPO_TOKEN` variable.
+⚠️ You _must_ provide [access
+credentials](/doc/self-hosted-runners#personal-access-token) via a `REPO_TOKEN`
+variable.
 
 The example above generates visual reports in pull requests:
-[![](/img/bitbucket_cloud_pr.png '=600')](https://bitbucket.org/iterative-ai/cml-base-case/pull-requests/2)
+[![](/img/bitbucket_cloud_pr.png
+'=600')](https://bitbucket.org/iterative-ai/cml-base-case/pull-requests/2)
 
-⚠️ CML works with Bitbucket Cloud, where you can use the
-[Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines) CI/CD
-system to run workflows automatically on triggering events. Bitbucket Server is
-not yet supported.
+⚠️ CML works with Bitbucket Cloud, where you can use the [Bitbucket
+Pipelines](https://bitbucket.org/product/features/pipelines) CI/CD system to run
+workflows automatically on triggering events. Bitbucket Server is not yet
+supported.
 
 ### Example projects
 
 - [Basic CML project](https://bitbucket.org/iterative-ai/cml-base-case)
 
-</tab>
-</toggle>
+</tab> </toggle>
 
 ## CML Commands
 
@@ -154,7 +152,8 @@ Below is a list of CML commands for starting cloud compute runners, writing and
 publishing Markdown reports to your CI/CD system.
 
 ∞ **[`runner`](/doc/ref/runner)**\
-Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners))\
+Launch a runner hosted by a cloud compute provider or locally on-premise (see
+[self-hosted runners](/doc/self-hosted-runners))\
 e.g. `cml runner launch --cloud={aws,azure,gcp,kubernetes} ...`
 
 ∞ **[`pr`](/doc/ref/pr)**\

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -1,8 +1,8 @@
 # Using CML
 
-A GitLab, GitHub, or Bitbucket account is required. Familiarity with [GitHub
-Actions](https://help.github.com/en/actions), [GitLab
-CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration),
+A GitLab, GitHub, or Bitbucket account is required. Familiarity with
+[GitHub Actions](https://help.github.com/en/actions),
+[GitLab CI/CD](https://about.gitlab.com/stages-devops-lifecycle/continuous-integration),
 or [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines) may
 also be beneficial.
 
@@ -47,11 +47,12 @@ jobs:
 The example above generates visual reports in pull requests:
 [![](/img/cml_first_report.png)](https://github.com/iterative/cml_base_case/pull/2)
 
-We helpfully provide CML and other useful libraries pre-installed on our [custom
-Docker images](/doc/self-hosted-runners#docker-images). In the above example,
-uncommenting the `container: docker://ghcr.io/iterative/cml:0-dvc2-base1` field
-will make the runner pull the CML Docker image. The image already has Node.js,
-Python 3, DVC and CML set up on an Ubuntu LTS base for convenience.
+We helpfully provide CML and other useful libraries pre-installed on our
+[custom Docker images](/doc/self-hosted-runners#docker-images). In the above
+example, uncommenting the
+`container: docker://ghcr.io/iterative/cml:0-dvc2-base1` field will make the
+runner pull the CML Docker image. The image already has Node.js, Python 3, DVC
+and CML set up on an Ubuntu LTS base for convenience.
 
 ### Example projects
 
@@ -80,19 +81,18 @@ create-CML-report:
     - cml comment create --publish report.md
 ```
 
-⚠️ You _must_ provide a [personal or project access token
-(PAT)](/doc/self-hosted-runners#personal-access-token) via a `REPO_TOKEN`
-variable.
+⚠️ You _must_ provide a
+[personal or project access token (PAT)](/doc/self-hosted-runners#personal-access-token)
+via a `REPO_TOKEN` variable.
 
 The example above generates visual reports in merge requests:
-[![](/img/GitLab_CML_report.png
-'=400')](https://gitlab.com/iterative.ai/cml-base-case/-/merge_requests/3)
+[![](/img/GitLab_CML_report.png '=400')](https://gitlab.com/iterative.ai/cml-base-case/-/merge_requests/3)
 
-We helpfully provide CML and other useful libraries pre-installed on our [custom
-Docker images](/doc/self-hosted-runners#docker-images). In the above example,
-the `image: iterativeai/cml:0-dvc2-base1` field will make the runner pull the
-CML Docker image. The image already has Node.js, Python 3, DVC and CML set up on
-an Ubuntu LTS base for convenience.
+We helpfully provide CML and other useful libraries pre-installed on our
+[custom Docker images](/doc/self-hosted-runners#docker-images). In the above
+example, the `image: iterativeai/cml:0-dvc2-base1` field will make the runner
+pull the CML Docker image. The image already has Node.js, Python 3, DVC and CML
+set up on an Ubuntu LTS base for convenience.
 
 ### Example projects
 
@@ -123,18 +123,17 @@ pipelines:
           - cml comment create --publish report.md
 ```
 
-⚠️ You _must_ provide [access
-credentials](/doc/self-hosted-runners#personal-access-token) via a `REPO_TOKEN`
-variable.
+⚠️ You _must_ provide
+[access credentials](/doc/self-hosted-runners#personal-access-token) via a
+`REPO_TOKEN` variable.
 
 The example above generates visual reports in pull requests:
-[![](/img/bitbucket_cloud_pr.png
-'=600')](https://bitbucket.org/iterative-ai/cml-base-case/pull-requests/2)
+[![](/img/bitbucket_cloud_pr.png '=600')](https://bitbucket.org/iterative-ai/cml-base-case/pull-requests/2)
 
-⚠️ CML works with Bitbucket Cloud, where you can use the [Bitbucket
-Pipelines](https://bitbucket.org/product/features/pipelines) CI/CD system to run
-workflows automatically on triggering events. Bitbucket Server is not yet
-supported.
+⚠️ CML works with Bitbucket Cloud, where you can use the
+[Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines) CI/CD
+system to run workflows automatically on triggering events. Bitbucket Server is
+not yet supported.
 
 ### Example projects
 
@@ -152,8 +151,7 @@ Below is a list of CML commands for starting cloud compute runners, writing and
 publishing Markdown reports to your CI/CD system.
 
 ∞ **[`runner`](/doc/ref/runner)**\
-Launch a runner hosted by a cloud compute provider or locally on-premise (see
-[self-hosted runners](/doc/self-hosted-runners))\
+Launch a runner hosted by a cloud compute provider or locally on-premise (see [self-hosted runners](/doc/self-hosted-runners))\
 e.g. `cml runner launch --cloud={aws,azure,gcp,kubernetes} ...`
 
 ∞ **[`pr`](/doc/ref/pr)**\

--- a/src/components/pages/Home/HeroSection/index.tsx
+++ b/src/components/pages/Home/HeroSection/index.tsx
@@ -119,9 +119,9 @@ const HeroSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
         }}
       >
         <HomeFeature heading="GitFlow for data science" icon={GitFlowIcon}>
-          Use GitLab or GitHub to manage ML experiments, track who trained ML
-          models or modified data and when. Codify data and models with DVC
-          instead of pushing to your Git repo.
+          Use GitLab, GitHub, or Bitbucket to manage ML experiments, track 
+          who trained ML models or modified data and when. Codify data and 
+          models with DVC instead of pushing to your Git repo.
         </HomeFeature>
         <HomeFeature
           heading="Auto reports for ML experiments"

--- a/src/components/pages/Home/HeroSection/index.tsx
+++ b/src/components/pages/Home/HeroSection/index.tsx
@@ -119,9 +119,9 @@ const HeroSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
         }}
       >
         <HomeFeature heading="GitFlow for data science" icon={GitFlowIcon}>
-          Use GitLab, GitHub, or Bitbucket to manage ML experiments, track 
-          who trained ML models or modified data and when. Codify data and 
-          models with DVC instead of pushing to your Git repo.
+          Use GitLab, GitHub, or Bitbucket to manage ML experiments, track who
+          trained ML models or modified data and when. Codify data and models
+          with DVC instead of pushing to your Git repo.
         </HomeFeature>
         <HomeFeature
           heading="Auto reports for ML experiments"


### PR DESCRIPTION
Fixed a few typos. I think the "For simplicity's sake" disclaimer in the getting started can be left out, since examples are available for all three platforms.

Rewrap has made the changes look more extensive than they are.