### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "group:allNonMajor"]
+  "extends": ["config:base", "group:allNonMajor", "schedule:weekends"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["@dvcorg", "iterative"],
+      "groupName": "Iterative Packages",
+      "schedule": ["at any time"]
+    }
+  ]
 }


### PR DESCRIPTION
We have Renovate `grouping` working on dvc.org. ([Example PR](https://github.com/iterative/dvc.org/pull/4048)). 

To denoise further added scheduling to weekends so that we can merge them on weekdays and also no scheduling for `Iterative Packages` as we might need them to be updated asap.