### PR TITLE
docs: clarify sections

### DIFF
--- a/content/docs/cml-with-dvc.md
+++ b/content/docs/cml-with-dvc.md
@@ -13,7 +13,7 @@ The `.github/workflows/cml.yaml` file to create this report is:
 name: CML & DVC
 on: [push]
 jobs:
-  run:
+  train-and-report:
     runs-on: ubuntu-latest
     container: docker://ghcr.io/iterative/cml:0-dvc2-base1
     steps:

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -9,11 +9,11 @@ and monitoring changing datasets.
 <cards>
 
   <card href="/doc/start" heading="Get Started">
-    A step-by-step introduction into basic CML features
+    Step-by-step introduction to basic CML features using our repository templates
   </card>
 
   <card href="/doc/usage" heading="Usage">
-    Study the detailed inner-workings of CML in its user guide.
+    Learn more about CML and setup your own repositories
   </card>
 
   <card href="/doc/cml-with-dvc" heading="CML with DVC">
@@ -21,7 +21,7 @@ and monitoring changing datasets.
   </card>
 
   <card href="/doc/self-hosted-runners" heading="Self-hosted Runners">
-    Use your own runners with CML
+    Use your own (cloud or on-premise) runners with CML
   </card>
 
 </cards>

--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -46,7 +46,7 @@ or a
 name: CML
 on: [push]
 jobs:
-  deploy-runner:
+  launch-runner:
     runs-on: ubuntu-latest
     steps:
       - uses: iterative/setup-cml@v1
@@ -64,8 +64,8 @@ jobs:
               --cloud-region=us-west \
               --cloud-type=p2.xlarge \
               --labels=cml-gpu
-  train-model:
-    needs: deploy-runner
+  train-and-report:
+    needs: launch-runner
     runs-on: [self-hosted, cml-gpu]
     timeout-minutes: 50400 # 35 days
     container:
@@ -92,7 +92,7 @@ jobs:
 <tab title="GitLab">
 
 ```yaml
-deploy-runner:
+launch-runner:
   image: iterativeai/cml:0-dvc2-base1
   script:
     - |
@@ -102,8 +102,8 @@ deploy-runner:
           --cloud-type=p2.xlarge \
           --cloud-spot \
           --labels=cml-gpu
-train-model:
-  needs: [deploy-runner]
+train-and-report:
+  needs: [launch-runner]
   tags:
     - cml-gpu
   image: iterativeai/cml:0-dvc2-base1-gpu
@@ -148,8 +148,8 @@ pipelines:
 </tab>
 </toggle>
 
-In the workflow above, the `deploy-runner` step launches an EC2 `p2.xlarge`
-instance in the `us-west` region. The `train-model` job then runs on the
+In the workflow above, the `launch-runner` step launches an EC2 `p2.xlarge`
+instance in the `us-west` region. The `train-and-report` job then runs on the
 newly-launched instance. See [Environment Variables](#environment-variables)
 below for details on the `secrets` required.
 

--- a/content/docs/start/bitbucket.md
+++ b/content/docs/start/bitbucket.md
@@ -38,7 +38,7 @@ $ git clone https://bitbucket.org/<your-username>/example-cml
            script:
              - pip install -r requirements.txt
              - python train.py
-
+             # Create CML report
              - cat metrics.txt >> report.md
              - echo '![](./plot.png)' >> report.md
              - cml comment create --publish report.md

--- a/content/docs/start/github.md
+++ b/content/docs/start/github.md
@@ -27,7 +27,7 @@ $ cd example_cml
    name: CML
    on: [push]
    jobs:
-     run:
+     train-and-report:
        runs-on: ubuntu-latest
        container: docker://ghcr.io/iterative/cml:0-dvc2-base1
        steps:
@@ -41,6 +41,7 @@ $ cd example_cml
              pip install -r requirements.txt
              python train.py
 
+             # Create CML report
              cat metrics.txt >> report.md
              echo '![](./plot.png)' >> report.md
              cml comment create --publish report.md

--- a/content/docs/start/gitlab.md
+++ b/content/docs/start/gitlab.md
@@ -35,7 +35,7 @@ $ cd example_cml
      script:
        - pip install -r requirements.txt
        - python train.py
-
+       # Create CML report
        - cat metrics.txt >> report.md
        - echo '![](./plot.png)' >> report.md
        - cml comment create --publish report.md

--- a/content/docs/usage.md
+++ b/content/docs/usage.md
@@ -15,7 +15,7 @@ The key file in any CML project is `.github/workflows/cml.yaml`:
 name: CML
 on: [push]
 jobs:
-  run:
+  train-and-report:
     runs-on: ubuntu-latest
     # optionally use a convenient Ubuntu LTS + DVC + CML container
     # container: docker://ghcr.io/iterative/cml:0-dvc2-base1

--- a/src/components/pages/Home/UseCasesSection/index.tsx
+++ b/src/components/pages/Home/UseCasesSection/index.tsx
@@ -73,11 +73,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                   <Collapser>
 
                     <Code filename=".gitlab-ci.yml" repo="https://gitlab.com/iterative.ai/cml-base-case">
-                      <div><span>stages:</span></div>
-                      <div>  <span>- cml_run</span></div>
-                      <div> </div>
-                      <div><span>cml:</span></div>
-                      <div>  <span>stage: cml_run</span></div>
+                      <div><span>train-and-report:</span></div>
                       <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>  <span>script:</span></div>
                       <Tooltip type="dependencies">
@@ -86,6 +82,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       </Tooltip>
                       <div> </div>
                       <Tooltip type="reports">
+                        <div>    <span># Create CML report</span></div>
                         <div>    <span>- cat metrics.txt &gt;&gt; report.md</span></div>
                         <div>    <span>- echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
                         <div>    <span>- cml comment create --publish report.md</span></div>
@@ -108,7 +105,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>on: [push]</div>
                       <div><span> </span></div>
                       <div><span>jobs:</span></div>
-                      <div>  <span>run:</span></div>
+                      <div>  <span>train-and-report:</span></div>
                       <div>    <span>runs-on: [ubuntu-latest]</span></div>
                       <div><span> </span></div>
                       <div>    <span>steps:</span></div>
@@ -155,11 +152,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                 gitlab={(
                   <Collapser>
                     <Code filename=".gitlab-ci.yml" repo="https://gitlab.com/iterative.ai/cml-dvc-case">
-                      <div><span>stages:</span></div>
-                      <div>  <span>- cml_run</span></div>
-                      <div><span> </span></div>
-                      <div><span>cml:</span></div>
-                      <div>  <span>stage: cml_run</span></div>
+                      <div><span>train-and-report:</span></div>
                       <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>  <span>script:</span></div>
                       <Tooltip type="dvc">
@@ -179,6 +172,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div>    <span>- dvc plots diff </span></div>
                       <div>      <span>--target loss.csv --show-vega master &gt; vega.json</span></div>
                       <Tooltip type="reports">
+                        <div>    <span># Create CML report</span></div>
                         <div>    <span>- vl2png vega.json &gt; plot.png</span></div>
                         <div>    <span>- echo &#x27;![](./plot.png)&#x27; &gt;&gt; report.md</span></div>
                         <div>    <span>- cml comment create --publish report.md</span></div>
@@ -200,7 +194,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span>on: [push]</span></div>
                       <div><span> </span></div>
                       <div><span>jobs:</span></div>
-                      <div>  <span>run:</span></div>
+                      <div>  <span>train-and-report:</span></div>
                       <div>    <span>runs-on: [ubuntu-latest]</span></div>
                       <div><span> </span></div>
                       <div>    <span>steps:</span></div>
@@ -265,11 +259,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                 gitlab={(
                   <Collapser>
                     <Code filename=".gitlab-ci.yml" repo="https://gitlab.com/iterative.ai/cml-tensorboard-case">
-                      <div><span>stages:</span></div>
-                      <div>    <span>- cml_run</span></div>
-                      <div><span> </span></div>
-                      <div><span>cml:</span></div>
-                      <div>    <span>stage: cml_run</span></div>
+                      <div><span>train-and-report:</span></div>
                       <div>    <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>    <span>script:</span></div>
                       <div>        <span>- pip install -r requirements.txt</span></div>
@@ -304,7 +294,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span>on: [push]</span></div>
                       <div></div>
                       <div><span>jobs:</span></div>
-                      <div>  <span>run:</span></div>
+                      <div>  <span>train-and-report:</span></div>
                       <div>    <span>runs-on: [ubuntu-latest]</span></div>
                       <div><span> </span></div>
                       <div>    <span>steps:</span></div>
@@ -360,13 +350,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                 gitlab={(
                   <Collapser>
                     <Code filename=".gitlab-ci.yml" repo="https://gitlab.com/iterative.ai/cml-runner-example">
-                      <div><span>stages:</span></div>
-                      <div>  <span>- deploy</span></div>
-                      <div>  <span>- train</span></div>
-                      <div><span> </span></div>
-                      <div><span>deploy_job:</span></div>
-                      <div>  <span>stage: deploy</span></div>
-                      <div>  <span>when: always</span></div>
+                      <div><span>launch-runner:</span></div>
                       <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>  <span>script:</span></div>
                       <Tooltip type="reports">
@@ -376,11 +360,9 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                         <div>      <span>--cloud-type t2.micro</span></div>
                         <div>      <span>--labels=cml-runner</span></div>
                       </Tooltip>
-                      <div><span> </span></div>
-                      <div><span>train_job:</span></div>
+                      <div><span>train-and-report:</span></div>
                       <Tooltip type="reports">
-                        <div>  <span>stage: train</span></div>
-                        <div>  <span>when: on_success</span></div>
+                        <div>  <span>needs: [launch-runner]</span></div>
                         <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                         <div>  <span>tags:</span></div>
                         <div>    <span>- cml-runner</span></div>
@@ -412,7 +394,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span>on: [push]</span></div>
                       <div><span> </span></div>
                       <div><span>jobs:</span></div>
-                      <div>  <span>deploy-runner:</span></div>
+                      <div>  <span>launch-runner:</span></div>
                       <div>    <span>runs-on: [ubuntu-latest]</span></div>
                       <div>    <span>steps:</span></div>
                       <div>      <span>- uses: actions/checkout@v3</span></div>
@@ -435,7 +417,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span> </span></div>
                       <div>  <span>model-training:</span></div>
                       <Tooltip type="reports">
-                        <div>    <span>needs: deploy-runner</span></div>
+                        <div>    <span>needs: launch-runner</span></div>
                         <div>    <span>runs-on: [self-hosted,cml-runner]</span></div>
                         <div>    <span>container: docker://iterativeai/cml:0-dvc2-base1</span></div>
                       </Tooltip>
@@ -478,13 +460,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                 gitlab={(
                   <Collapser>
                     <Code filename=".gitlab-ci.yml" repo="https://gitlab.com/iterative.ai/cml-cloud-case">
-                      <div><span>stages:</span></div>
-                      <div>  <span>- deploy</span></div>
-                      <div>  <span>- train</span></div>
-                      <div><span> </span></div>
-                      <div><span>deploy_job:</span></div>
-                      <div>  <span>stage: deploy</span></div>
-                      <div>  <span>when: always</span></div>
+                      <div><span>launch-runner:</span></div>
                       <div>  <span>image: iterativeai/cml:0-dvc2-base1</span></div>
                       <div>  <span>script:</span></div>
                       <Tooltip type="reports">
@@ -493,16 +469,14 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                         <div>      <span>--cloud-region us-west \</span></div>
                         <div>      <span>--cloud-type=p2.xlarge \</span></div>
                         <div>      <span>--cloud-hdd-size 64 \</span></div>
-                        <div>      <span>--labels=cml-runner-gpu</span></div>
+                        <div>      <span>--labels=cml-gpu</span></div>
                       </Tooltip>
-                      <div><span> </span></div>
-                      <div><span>train_job:</span></div>
+                      <div><span>train-and-report:</span></div>
+                      <div>  <span>needs: [launch-runner]</span></div>
                       <Tooltip type="reports">
-                        <div>  <span>stage: train</span></div>
-                        <div>  <span>when: on_success</span></div>
                         <div>  <span>image: iterativeai/cml:0-dvc2-base1-gpu</span></div>
                         <div>  <span>tags:</span></div>
-                        <div>    <span>- cml-runner-gpu</span></div>
+                        <div>    <span>- cml-gpu</span></div>
                       </Tooltip>
                       <div><span> </span></div>
                       <div>  <span>script:</span></div>
@@ -552,7 +526,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                       <div><span>on: [push]</span></div>
                       <div><span> </span></div>
                       <div><span>jobs:</span></div>
-                      <div>  <span>deploy-runner:</span></div>
+                      <div>  <span>launch-runner:</span></div>
                       <div>    <span>runs-on: [ubuntu-latest]</span></div>
                       <div>    <span>steps:</span></div>
                       <div>      <span>- uses: actions/checkout@v3</span></div>
@@ -574,9 +548,9 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
                         <div>          <span>--labels=cml-runner</span></div>
                       </Tooltip>
                       <div><span> </span></div>
-                      <div>  <span>run:</span></div>
+                      <div>  <span>train-and-report:</span></div>
                       <Tooltip type="reports">
-                        <div>    <span>needs: deploy-runner</span></div>
+                        <div>    <span>needs: launch-runner</span></div>
                         <div>    <span>runs-on: [self-hosted,cml-runner]</span></div>
                         <div>    <span>container: </span></div>
                         <div>      <span>image: docker://iterativeai/cml:0-dvc2-base1-gpu</span></div>

--- a/src/components/pages/Home/UseCasesSection/index.tsx
+++ b/src/components/pages/Home/UseCasesSection/index.tsx
@@ -472,7 +472,7 @@ const UseCasesSection: React.ForwardRefRenderFunction<HTMLElement> = () => (
           },
           ,
           {
-            name: "Advanced GPU Case",
+            name: "Runner Cloud GPU",
             content: (
               <Switchable
                 gitlab={(


### PR DESCRIPTION
- docs landing: clarify section purposes
- rename home page "CML Use Case" tab `Advanced GPU Case` -> `Runner Cloud GPU`
- tidy workflow/report section names