### PR TITLE
Fix stars pulling from DVC

### DIFF
--- a/src/gatsby/hooks/stars.ts
+++ b/src/gatsby/hooks/stars.ts
@@ -18,7 +18,7 @@ export default function useStars(): number | null {
   // Run an IIFE to update from the server on the client side.
   useEffect(() => {
     ;(async (): Promise<void> => {
-      const res = await fetch(`/api/github/stars`)
+      const res = await fetch(`/api/github/stars?repo=cml`)
       if (res.status === 200) {
         const json = await res.json()
         setStars(json.stars)


### PR DESCRIPTION
This PR adds a query to the stars request made by this website to use the repo for the project in question, where it currently is pulling from dvc.

https://github.com/iterative/mlem.ai/pull/206 is the same thing for mlem.ai