### PR TITLE
Allow higher node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/iterative/cml.dev#readme",
   "engines": {
-    "node": "<=16.17"
+    "node": "^16 || ^18"
   },
   "dependencies": {
     "@dvcorg/gatsby-theme-iterative": "^0.1.19",


### PR DESCRIPTION
Currently, the node version is explicitly limited to less than 16.17. It prevents using the latest version. It is configured to allow higher versions.

It's already upgraded for other websites through Renovate.