### PR TITLE
Simplify SSH public key provisioning guidance

### DIFF
--- a/content/docs/ref/runner.md
+++ b/content/docs/ref/runner.md
@@ -316,7 +316,7 @@ user:
 
 ```cli
 $ cml runner launch \
-  --cloud-startup-script=$(echo 'echo "$(curl https://github.com/${{ github.actor }}.keys)" >> /home/ubuntu/.ssh/authorized_keys' | base64 -w 0) \
+  --cloud-startup-script=$(echo 'curl https://github.com/${{ github.actor }}.keys >> /home/ubuntu/.ssh/authorized_keys' | base64 -w 0) \
   ...
 ```
 


### PR DESCRIPTION
A bit simpler, with the same effect