### PR TITLE
Temporarily remove stars

### DIFF
--- a/src/components/atoms/GithubLine/index.tsx
+++ b/src/components/atoms/GithubLine/index.tsx
@@ -1,15 +1,11 @@
 import React from 'react'
 
-import { Box, Flex } from '@theme-ui/components'
+import { Flex } from '@theme-ui/components'
 
 import SmartLink from '../SmartLink'
 import { ReactComponent as GithubIcon } from '@media/icons/github.svg'
-import { ReactComponent as StarIcon } from '@media/icons/star.svg'
-import useStars from '../../../gatsby/hooks/stars'
 
 const GithubLine: React.FC = () => {
-  const stars = useStars()
-
   return (
     <Flex
       sx={{
@@ -36,16 +32,6 @@ const GithubLine: React.FC = () => {
       >
         GitHub
       </SmartLink>
-      {stars && (
-        <Flex as="span">
-          <Box as="span" sx={{ ml: '7px' }}>
-            <StarIcon width="11" height="11" />
-          </Box>
-          <Box as="span" sx={{ ml: '7px', fontWeight: 500, display: 'block' }}>
-            {stars}
-          </Box>
-        </Flex>
-      )}
     </Flex>
   )
 }

--- a/src/gatsby/models.js
+++ b/src/gatsby/models.js
@@ -1,7 +1,6 @@
 const imageSourcePaths = require('./models/image-source-paths')
-const github = require('./models/github')
 const pruneCache = require('./models/prune-cache')
 
-const models = [imageSourcePaths, github, pruneCache]
+const models = [imageSourcePaths, pruneCache]
 
 module.exports = models


### PR DESCRIPTION
This temporary measure will (hopefully) will fix `/doc` not rendering. We'll revert once we get the GH proxy API back up.