### PR TITLE
Add note about token role assignment for Gitlab

### DIFF
--- a/content/docs/self-hosted-runners.md
+++ b/content/docs/self-hosted-runners.md
@@ -324,7 +324,7 @@ Use either:
   ([specific](https://docs.gitlab.com/ee/ci/runners/runners_scope.html#specific-runners)),
   but not for instance-level
   ([shared](https://docs.gitlab.com/ee/ci/runners/runners_scope.html#shared-runners))
-  runners.
+  runners. Ensure that the token is assigned at least the "Developer" role.
 
 For instance, to use a personal access token:
 


### PR DESCRIPTION
I recently ran into the same issue as the users in this [issue](https://github.com/iterative/cml/issues/1363#issuecomment-1459714860) and noticed that the fix was still missing from the docs.

This should fix it.